### PR TITLE
Add single node pytorchjob yaml

### DIFF
--- a/training/ilab-pytorch-job.yaml
+++ b/training/ilab-pytorch-job.yaml
@@ -1,8 +1,8 @@
 apiVersion: kubeflow.org/v1
 kind: PyTorchJob
 metadata:
-  name: ilab-test4
-  namespace: default
+  name: <TEST-NAME>
+  namespace: <NAMESPACE>
 spec:
   pytorchReplicaSpecs:
     Master:
@@ -15,56 +15,7 @@ spec:
           containers:
             - args:
                 - |-
-
-                  program_path=$(mktemp -d)
-                  read -r -d '' SCRIPT << EOM
-
-                  def train_func():
-                      from instructlab.training import (
-                      run_training,
-                      TorchrunArgs,
-                      TrainingArgs,
-                      DeepSpeedOptions,
-                      )
-
-                      # define training-specific arguments
-                      training_args = TrainingArgs(
-                          deepspeed_options = DeepSpeedOptions(cpu_offload_optimizer=True),
-                          # define data-specific arguments
-                          model_path = "ibm-granite/granite-7b-base",
-                          data_path = "training/sample-data/train_all_pruned_SDG.jsonl",
-                          ckpt_output_dir = "data/saved_checkpoints",
-                          data_output_dir = "data/outputs",
-
-                          # define model-trianing parameters
-                          max_seq_len = 4096,
-                          max_batch_len = 20000,
-                          num_epochs = 2,
-                          effective_batch_size = 3840,
-                          save_samples = 250000,
-                          learning_rate = 2e-6,
-                          warmup_steps = 800,
-                          is_padding_free = True, # set this to true when using Granite-based models
-                          random_seed = 42,
-                          checkpoint_at_epoch = True,
-                      )
-
-                      torchrun_args = TorchrunArgs(
-                          nnodes = 1, # number of machines 
-                          nproc_per_node = 4, # num GPUs per machine
-                          node_rank = 0, # node rank for this machine
-                          rdzv_id = 123,
-                          rdzv_endpoint = '127.0.0.1:12345',
-                      )
-                      run_training(
-                          torch_args=torchrun_args,
-                          train_args=training_args)
-
-                  train_func()
-
-                  EOM
-                  printf "%s" "$SCRIPT" > "$program_path/ephemeral_script.py"
-                  python3.11 -u "$program_path/ephemeral_script.py"
+                  python3.11 -u "run.py"
               command:
                 - /bin/bash
                 - '-c'

--- a/training/ilab-pytorch-job.yaml
+++ b/training/ilab-pytorch-job.yaml
@@ -1,0 +1,76 @@
+apiVersion: kubeflow.org/v1
+kind: PyTorchJob
+metadata:
+  name: ilab-test4
+  namespace: default
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: 'false'
+        spec:
+          containers:
+            - args:
+                - |-
+
+                  program_path=$(mktemp -d)
+                  read -r -d '' SCRIPT << EOM
+
+                  def train_func():
+                      from instructlab.training import (
+                      run_training,
+                      TorchrunArgs,
+                      TrainingArgs,
+                      DeepSpeedOptions,
+                      )
+
+                      # define training-specific arguments
+                      training_args = TrainingArgs(
+                          deepspeed_options = DeepSpeedOptions(cpu_offload_optimizer=True),
+                          # define data-specific arguments
+                          model_path = "ibm-granite/granite-7b-base",
+                          data_path = "training/sample-data/train_all_pruned_SDG.jsonl",
+                          ckpt_output_dir = "data/saved_checkpoints",
+                          data_output_dir = "data/outputs",
+
+                          # define model-trianing parameters
+                          max_seq_len = 4096,
+                          max_batch_len = 20000,
+                          num_epochs = 2,
+                          effective_batch_size = 3840,
+                          save_samples = 250000,
+                          learning_rate = 2e-6,
+                          warmup_steps = 800,
+                          is_padding_free = True, # set this to true when using Granite-based models
+                          random_seed = 42,
+                          checkpoint_at_epoch = True,
+                      )
+
+                      torchrun_args = TorchrunArgs(
+                          nnodes = 1, # number of machines 
+                          nproc_per_node = 4, # num GPUs per machine
+                          node_rank = 0, # node rank for this machine
+                          rdzv_id = 123,
+                          rdzv_endpoint = '127.0.0.1:12345',
+                      )
+                      run_training(
+                          torch_args=torchrun_args,
+                          train_args=training_args)
+
+                  train_func()
+
+                  EOM
+                  printf "%s" "$SCRIPT" > "$program_path/ephemeral_script.py"
+                  python3.11 -u "$program_path/ephemeral_script.py"
+              command:
+                - /bin/bash
+                - '-c'
+                - '--'
+              image: 'quay.io/michaelclifford/test-train:0.0.11'
+              name: pytorch
+              resources: {}
+  runPolicy:
+    suspend: false


### PR DESCRIPTION
This PR adds a single node pytorch job for the single node deployment created in this [PR](https://github.com/redhat-et/ilab-on-ocp/pull/3). The pytorch job can then be updated to add more worker nodes along with the master nodes. 

One caveat is that the entire [run.py](https://github.com/MichaelClifford/ilab-on-ocp/blob/train/training/run.py) script is in the yaml here. Maybe there is a better way to structure this. 

The pytorch job assumes the kubeflow training operator installed on the cluster which was done using the command:
`oc apply -k "github.com/kubeflow/training-operator.git/manifests/overlays/standalone?ref=v1.7.0"`