### PR TITLE
Make the training args accessible to users

### DIFF
--- a/training/run.py
+++ b/training/run.py
@@ -1,3 +1,5 @@
+import argparse
+import os
 from instructlab.training import (
     run_training,
     TorchrunArgs,
@@ -5,34 +7,62 @@ from instructlab.training import (
     DeepSpeedOptions,
 )
 
+parser = argparse.ArgumentParser()
+
+# Training Args
+parser.add_argument("--cpu_offload", default=True)
+parser.add_argument("--model_path", default="ibm-granite/granite-7b-base")
+parser.add_argument("--data_path", default="training/sample-data/train_all_pruned_SDG.jsonl")
+parser.add_argument("--ckpt_output_dir",default="data/saved_checkpoints")
+parser.add_argument("--data_output_dir", default="data/outputs")
+parser.add_argument("--max_seq_len", default=4096)
+parser.add_argument("--max_batch_len", default=20000)
+parser.add_argument("--num_epochs", default=2)
+parser.add_argument("--effective_batch_size", default=3840)
+parser.add_argument("--save_samples", default=0)
+parser.add_argument("--learning_rate", default=2e-6)
+parser.add_argument("--warmup_steps", default=800)
+parser.add_argument("--is_padding_free", default=True)
+parser.add_argument("--random_seed", default=42)
+parser.add_argument("--checkpoint_at_epoch", default=True)
+
+# Torchrun Args
+parser.add_argument("--nnodes", default=1)
+parser.add_argument("--nproc_per_node", default=1)
+parser.add_argument("--node_rank", default=0)
+parser.add_argument("--rdzv_id", default=123)
+parser.add_argument("--rdzv_endpoint", default= "127.0.0.1:12345")
+
+args = parser.parse_args()
+
 # define training-specific arguments
 training_args = TrainingArgs(
-    deepspeed_options = DeepSpeedOptions(cpu_offload_optimizer=True),
+    deepspeed_options = DeepSpeedOptions(cpu_offload_optimizer=args.cpu_offload),
     # define data-specific arguments
-    model_path = "ibm-granite/granite-7b-base",
-    data_path = "training/sample-data/train_all_pruned_SDG.jsonl",
-    ckpt_output_dir = "data/saved_checkpoints",
-    data_output_dir = "data/outputs",
+    model_path = args.model_path,
+    data_path = args.data_path,
+    ckpt_output_dir = args.ckpt_output_dir,
+    data_output_dir = args.data_output_dir,
 
     # define model-trianing parameters
-    max_seq_len = 4096,
-    max_batch_len = 20000,
-    num_epochs = 2,
-    effective_batch_size = 3840,
-    save_samples = 0,
-    learning_rate = 2e-6,
-    warmup_steps = 800,
-    is_padding_free = True, # set this to true when using Granite-based models
-    random_seed = 42,
-    checkpoint_at_epoch = True,
+    max_seq_len = args.max_seq_len,
+    max_batch_len = args.max_batch_len,
+    num_epochs = args.num_epochs,
+    effective_batch_size = args.effective_batch_size,
+    save_samples = args.save_samples,
+    learning_rate = args.learning_rate,
+    warmup_steps = args.warmup_steps,
+    is_padding_free = args.is_padding_free, # set this to true when using Granite-based models
+    random_seed = args.random_seed,
+    checkpoint_at_epoch = args.checkpoint_at_epoch
 )
 
 torchrun_args = TorchrunArgs(
-    nnodes = 1, # number of machines 
-    nproc_per_node = 2, # num GPUs per machine
-    node_rank = 0, # node rank for this machine
-    rdzv_id = 123,
-    rdzv_endpoint = '127.0.0.1:12345',
+    nnodes = args.nnodes, # number of machines 
+    nproc_per_node = args.nproc_per_node, # num GPUs per machine
+    node_rank = args.node_rank, # node rank for this machine
+    rdzv_id = args.rdzv_id,
+    rdzv_endpoint = args.rdzv_endpoint,
 )
 
 run_training(


### PR DESCRIPTION
All training args had been hardcoded in the first iteration. This PR makes all the parameters used in `train/run.py` command line options. The defaults for each parameter are set to their previous hardcoded value. So this script should still work as before if no parameter options are provided. 