### PR TITLE
feat(kfp): add train stage

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -126,6 +126,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             name_suffix=sdg_input_pvc_task.output,
             output_pvc_name=output_pvc_task.output,
         )
+        pytorchjob_manifest_task.set_caching_options(False)
 
         kubectl_apply_task = kubectl_apply_op(
             manifest=pytorchjob_manifest_task.outputs["manifest"]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -492,57 +492,61 @@ deploymentSpec:
           \ 2\n    nnodes = 2\n\n    manifest = inspect.cleandoc(\n        f\"\"\"\
           \n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n      \
           \  metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
-          \ \"{nprocPerNode}\"\n          pytorchReplicaSpecs:\n            Master:\n\
-          \              replicas: 1\n              restartPolicy: OnFailure\n   \
-          \           template:\n                metadata:\n                  annotations:\n\
+          \ \\\\\"{nprocPerNode}\\\\\"\n          pytorchReplicaSpecs:\n         \
+          \   Master:\n              replicas: 1\n              restartPolicy: OnFailure\n\
+          \              template:\n                metadata:\n                  annotations:\n\
           \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
           \                  containers:\n                    - args:\n          \
           \              - |\n                          mkdir -p /output/model;\n\
           \                          mkdir -p /output/data;\n                    \
-          \      python3.11 -u run.py --nnodes {nnodes} --nproc_per_node {nprocPerNode}\
-          \ --node_rank \\\\$RANK --rdzv_endpoint \\\\$MASTER_ADDR:\\\\$MASTER_PORT\
-          \ --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl\
-          \ --ckpt_output_dir /output/model --data_output_dir /output/data\n     \
-          \                 command:\n                        - /bin/bash\n      \
-          \                  - '-c'\n                        - '--'\n            \
-          \          image: {image}\n                      name: pytorch\n       \
-          \               volumeMounts:\n                        - mountPath: /input_data\n\
-          \                          name: input-data\n                          readOnly:\
-          \ true\n                        - mountPath: /input_model\n            \
-          \              name: model\n                          readOnly: true\n \
-          \                       - mountPath: /output\n                         \
-          \ name: output\n                      resources:\n                     \
-          \   requests:\n                          memory: 8Gi\n                 \
-          \         cpu: 2\n                          \"nvidia.com/gpu\": {nprocPerNode}\n\
+          \      python3.11 -u run.py --model_path /input_model/model --data_path\
+          \ /input_data/sdg/*_train_msgs*.jsonl --ckpt_output_dir /output/model --data_output_dir\
+          \ /output/data\n                      command:\n                       \
+          \ - /bin/bash\n                        - '-c'\n                        -\
+          \ '--'\n                      image: {image}\n                      name:\
+          \ pytorch\n                      volumeMounts:\n                       \
+          \ - mountPath: /input_data\n                          name: input-data\n\
+          \                          readOnly: true\n                        - mountPath:\
+          \ /input_model\n                          name: model\n                \
+          \          readOnly: true\n                        - mountPath: /output\n\
+          \                          name: output\n                      env:\n  \
+          \                      - name: NNODES\n                          value:\
+          \ \\\\\"{nnodes}\\\\\"\n                        - name: NPROC_PER_NODE\n\
+          \                          value: \\\\\"{nprocPerNode}\\\\\"\n         \
+          \             resources:\n                        requests:\n          \
+          \                memory: 8Gi\n                          cpu: 2\n       \
+          \                   \"nvidia.com/gpu\": {nprocPerNode}\n               \
+          \         limits:\n                          memory: 8Gi\n             \
+          \             cpu: 2\n                          \"nvidia.com/gpu\": {nprocPerNode}\n\
+          \                  volumes:\n                    - name: input-data\n  \
+          \                    persistentVolumeClaim:\n                        claimName:\
+          \ {input_pvc_name}\n                    - name: model\n                \
+          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
+          \                    - name: output\n                      persistentVolumeClaim:\n\
+          \                        claimName: {output_pvc_name}\n            Worker:\n\
+          \              replicas: {nnodes-1}\n              restartPolicy: OnFailure\n\
+          \              template:\n                metadata:\n                  annotations:\n\
+          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
+          \                  containers:\n                    - args:\n          \
+          \              - |\n                          mkdir -p /output/model;\n\
+          \                          mkdir -p /output/data;\n                    \
+          \      python3.11 -u run.py --model_path /input_model/model --data_path\
+          \ /input_data/sdg/*_train_msgs*.jsonl --ckpt_output_dir /tmp/model --data_output_dir\
+          \ /tmp/data\n                      command:\n                        - /bin/bash\n\
+          \                        - '-c'\n                        - '--'\n      \
+          \                image: {image}\n                      name: pytorch\n \
+          \                     volumeMounts:\n                        - mountPath:\
+          \ /input_data\n                          name: input-data\n            \
+          \              readOnly: true\n                        - mountPath: /input_model\n\
+          \                          name: model\n                          readOnly:\
+          \ true\n                      env:\n                        - name: NNODES\n\
+          \                          value: \\\\\"{nnodes}\\\\\"\n               \
+          \         - name: NPROC_PER_NODE\n                          value: \\\\\"\
+          {nprocPerNode}\\\\\"\n                      resources:\n               \
+          \         requests:\n                          memory: 8Gi\n           \
+          \               cpu: 2\n                          \"nvidia.com/gpu\": {nprocPerNode}\n\
           \                        limits:\n                          memory: 8Gi\n\
           \                          cpu: 2\n                          \"nvidia.com/gpu\"\
-          : {nprocPerNode}\n                  volumes:\n                    - name:\
-          \ input-data\n                      persistentVolumeClaim:\n           \
-          \             claimName: {input_pvc_name}\n                    - name: model\n\
-          \                      persistentVolumeClaim:\n                        claimName:\
-          \ {model_pvc_name}\n                    - name: output\n               \
-          \       persistentVolumeClaim:\n                        claimName: {output_pvc_name}\n\
-          \            Worker:\n              replicas: {nnodes-1}\n             \
-          \ restartPolicy: OnFailure\n              template:\n                metadata:\n\
-          \                  annotations:\n                    sidecar.istio.io/inject:\
-          \ 'false'\n                spec:\n                  containers:\n      \
-          \              - args:\n                        - |\n                  \
-          \        python3.11 -u run.py --nnodes {nnodes} --nproc_per_node {nprocPerNode}\
-          \  --node_rank \\\\$RANK --rdzv_endpoint \\\\$MASTER_ADDR:\\\\$MASTER_PORT\
-          \ --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl\
-          \ --ckpt_output_dir /tmp/model --data_output_dir /tmp/data\n           \
-          \           command:\n                        - /bin/bash\n            \
-          \            - '-c'\n                        - '--'\n                  \
-          \    image: {image}\n                      name: pytorch\n             \
-          \         volumeMounts:\n                        - mountPath: /input_data\n\
-          \                          name: input-data\n                          readOnly:\
-          \ true\n                        - mountPath: /input_model\n            \
-          \              name: model\n                          readOnly: true\n \
-          \                     resources:\n                        requests:\n  \
-          \                        memory: 8Gi\n                          cpu: 2\n\
-          \                          \"nvidia.com/gpu\": {nprocPerNode}\n        \
-          \                limits:\n                          memory: 8Gi\n      \
-          \                    cpu: 2\n                          \"nvidia.com/gpu\"\
           : {nprocPerNode}\n                  volumes:\n                    - name:\
           \ input-data\n                      persistentVolumeClaim:\n           \
           \             claimName: {input_pvc_name}\n                    - name: model\n\
@@ -840,8 +844,7 @@ root:
         taskInfo:
           name: pvc-to-model-op
       pytorchjob-manifest-op:
-        cachingOptions:
-          enableCache: true
+        cachingOptions: {}
         componentRef:
           name: comp-pytorchjob-manifest-op
         dependentTasks:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -496,7 +496,7 @@ deploymentSpec:
           \            annotations:\n                    sidecar.istio.io/inject:\
           \ 'false'\n                spec:\n                  containers:\n      \
           \              - args:\n                        - |\n                  \
-          \        mkdir /output/model;\n                          mkdir /output/data;\n\
+          \        mkdir -p /output/model;\n                          mkdir -p /output/data;\n\
           \                          python3.11 -u run.py --nnodes 2 --nproc_per_node\
           \ 2 --node_rank \"$(RANK)\" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT)\
           \ --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl\

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -514,16 +514,15 @@ deploymentSpec:
           \ \\\\\"{nnodes}\\\\\"\n                        - name: NPROC_PER_NODE\n\
           \                          value: \\\\\"{nprocPerNode}\\\\\"\n         \
           \             resources:\n                        requests:\n          \
-          \                memory: 8Gi\n                          cpu: 2\n       \
-          \                   \"nvidia.com/gpu\": {nprocPerNode}\n               \
-          \         limits:\n                          memory: 8Gi\n             \
-          \             cpu: 2\n                          \"nvidia.com/gpu\": {nprocPerNode}\n\
-          \                  volumes:\n                    - name: input-data\n  \
-          \                    persistentVolumeClaim:\n                        claimName:\
-          \ {input_pvc_name}\n                    - name: model\n                \
-          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
-          \                    - name: output\n                      persistentVolumeClaim:\n\
-          \                        claimName: {output_pvc_name}\n            Worker:\n\
+          \                cpu: 2\n                          \"nvidia.com/gpu\": {nprocPerNode}\n\
+          \                        limits:\n                          cpu: 2\n   \
+          \                       \"nvidia.com/gpu\": {nprocPerNode}\n           \
+          \       volumes:\n                    - name: input-data\n             \
+          \         persistentVolumeClaim:\n                        claimName: {input_pvc_name}\n\
+          \                    - name: model\n                      persistentVolumeClaim:\n\
+          \                        claimName: {model_pvc_name}\n                 \
+          \   - name: output\n                      persistentVolumeClaim:\n     \
+          \                   claimName: {output_pvc_name}\n            Worker:\n\
           \              replicas: {nnodes-1}\n              restartPolicy: OnFailure\n\
           \              template:\n                metadata:\n                  annotations:\n\
           \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
@@ -543,9 +542,8 @@ deploymentSpec:
           \                          value: \\\\\"{nnodes}\\\\\"\n               \
           \         - name: NPROC_PER_NODE\n                          value: \\\\\"\
           {nprocPerNode}\\\\\"\n                      resources:\n               \
-          \         requests:\n                          memory: 8Gi\n           \
-          \               cpu: 2\n                          \"nvidia.com/gpu\": {nprocPerNode}\n\
-          \                        limits:\n                          memory: 8Gi\n\
+          \         requests:\n                          cpu: 2\n                \
+          \          \"nvidia.com/gpu\": {nprocPerNode}\n                        limits:\n\
           \                          cpu: 2\n                          \"nvidia.com/gpu\"\
           : {nprocPerNode}\n                  volumes:\n                    - name:\
           \ input-data\n                      persistentVolumeClaim:\n           \

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -489,7 +489,7 @@ deploymentSpec:
           outputs\", manifest=str, name=str):\n    import inspect\n\n    Outputs =\
           \ NamedTuple(\"outputs\", manifest=str, name=str)\n    name = f\"train-{name_suffix.rstrip('-sdg')}\"\
           \n\n    image = 'quay.io/tcoufal/ilab-train:latest'\n    nprocPerNode =\
-          \ 2\n    nnodes = 2\n\n    manifest = inspect.cleandoc(\n        f\"\"\"\
+          \ 2\n    nnodes = 1\n\n    manifest = inspect.cleandoc(\n        f\"\"\"\
           \n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n      \
           \  metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
           \ \\\\\"{nprocPerNode}\\\\\"\n          pytorchReplicaSpecs:\n         \

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -488,17 +488,19 @@ deploymentSpec:
           \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n) -> NamedTuple(\"\
           outputs\", manifest=str, name=str):\n    import inspect\n\n    Outputs =\
           \ NamedTuple(\"outputs\", manifest=str, name=str)\n    name = f\"train-{name_suffix.rstrip('-sdg')}\"\
-          \n\n    image = 'quay.io/tcoufal/ilab-train:latest'\n\n    manifest = inspect.cleandoc(\n\
-          \        f\"\"\"\n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n\
-          \        metadata:\n          name: {name}\n        spec:\n          pytorchReplicaSpecs:\n\
-          \            Master:\n              replicas: 1\n              restartPolicy:\
-          \ OnFailure\n              template:\n                metadata:\n      \
-          \            annotations:\n                    sidecar.istio.io/inject:\
-          \ 'false'\n                spec:\n                  containers:\n      \
-          \              - args:\n                        - |\n                  \
-          \        mkdir -p /output/model;\n                          mkdir -p /output/data;\n\
-          \                          python3.11 -u run.py --nnodes 2 --nproc_per_node\
-          \ 2 --node_rank \"$(RANK)\" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT)\
+          \n\n    image = 'quay.io/tcoufal/ilab-train:latest'\n    nprocPerNode =\
+          \ 2\n    nnodes = 2\n\n    manifest = inspect.cleandoc(\n        f\"\"\"\
+          \n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n      \
+          \  metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
+          \ \"{nprocPerNode}\"\n          pytorchReplicaSpecs:\n            Master:\n\
+          \              replicas: 1\n              restartPolicy: OnFailure\n   \
+          \           template:\n                metadata:\n                  annotations:\n\
+          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
+          \                  containers:\n                    - args:\n          \
+          \              - |\n                          mkdir -p /output/model;\n\
+          \                          mkdir -p /output/data;\n                    \
+          \      python3.11 -u run.py --nnodes {nnodes} --nproc_per_node {nprocPerNode}\
+          \ --node_rank \\\\$RANK --rdzv_endpoint \\\\$MASTER_ADDR:\\\\$MASTER_PORT\
           \ --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl\
           \ --ckpt_output_dir /output/model --data_output_dir /output/data\n     \
           \                 command:\n                        - /bin/bash\n      \
@@ -511,21 +513,22 @@ deploymentSpec:
           \                       - mountPath: /output\n                         \
           \ name: output\n                      resources:\n                     \
           \   requests:\n                          memory: 8Gi\n                 \
-          \         cpu: 2\n                          \"nvidia.com/gpu\": 1\n    \
-          \                    limits:\n                          memory: 8Gi\n  \
-          \                        cpu: 2\n                          \"nvidia.com/gpu\"\
-          : 1\n                  volumes:\n                    - name: input-data\n\
+          \         cpu: 2\n                          \"nvidia.com/gpu\": {nprocPerNode}\n\
+          \                        limits:\n                          memory: 8Gi\n\
+          \                          cpu: 2\n                          \"nvidia.com/gpu\"\
+          : {nprocPerNode}\n                  volumes:\n                    - name:\
+          \ input-data\n                      persistentVolumeClaim:\n           \
+          \             claimName: {input_pvc_name}\n                    - name: model\n\
           \                      persistentVolumeClaim:\n                        claimName:\
-          \ {input_pvc_name}\n                    - name: model\n                \
-          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
-          \                    - name: output\n                      persistentVolumeClaim:\n\
-          \                        claimName: {output_pvc_name}\n            Worker:\n\
-          \              replicas: 1\n              restartPolicy: OnFailure\n   \
-          \           template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  containers:\n                    - args:\n          \
-          \              - |\n                          python3.11 -u run.py --nnodes\
-          \ 2 --nproc_per_node 2 --node_rank \"$(RANK)\" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT)\
+          \ {model_pvc_name}\n                    - name: output\n               \
+          \       persistentVolumeClaim:\n                        claimName: {output_pvc_name}\n\
+          \            Worker:\n              replicas: {nnodes-1}\n             \
+          \ restartPolicy: OnFailure\n              template:\n                metadata:\n\
+          \                  annotations:\n                    sidecar.istio.io/inject:\
+          \ 'false'\n                spec:\n                  containers:\n      \
+          \              - args:\n                        - |\n                  \
+          \        python3.11 -u run.py --nnodes {nnodes} --nproc_per_node {nprocPerNode}\
+          \  --node_rank \\\\$RANK --rdzv_endpoint \\\\$MASTER_ADDR:\\\\$MASTER_PORT\
           \ --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl\
           \ --ckpt_output_dir /tmp/model --data_output_dir /tmp/data\n           \
           \           command:\n                        - /bin/bash\n            \
@@ -537,14 +540,15 @@ deploymentSpec:
           \              name: model\n                          readOnly: true\n \
           \                     resources:\n                        requests:\n  \
           \                        memory: 8Gi\n                          cpu: 2\n\
-          \                          \"nvidia.com/gpu\": 1\n                     \
-          \   limits:\n                          memory: 8Gi\n                   \
-          \       cpu: 2\n                          \"nvidia.com/gpu\": 1\n      \
-          \            volumes:\n                    - name: input-data\n        \
-          \              persistentVolumeClaim:\n                        claimName:\
-          \ {input_pvc_name}\n                    - name: model\n                \
-          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
-          \        \"\"\"\n    )\n\n    return Outputs(manifest, name)\n\n"
+          \                          \"nvidia.com/gpu\": {nprocPerNode}\n        \
+          \                limits:\n                          memory: 8Gi\n      \
+          \                    cpu: 2\n                          \"nvidia.com/gpu\"\
+          : {nprocPerNode}\n                  volumes:\n                    - name:\
+          \ input-data\n                      persistentVolumeClaim:\n           \
+          \             claimName: {input_pvc_name}\n                    - name: model\n\
+          \                      persistentVolumeClaim:\n                        claimName:\
+          \ {model_pvc_name}\n        \"\"\"\n    )\n\n    return Outputs(manifest,\
+          \ name)\n\n"
         image: registry.access.redhat.com/ubi9/python-311:latest
     exec-sdg-op:
       container:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2,11 +2,242 @@
 # Name: instructlab
 # Description: InstructLab pipeline
 # Inputs:
+#    base_model: str [Default: 'ibm-granite/granite-7b-base']
 #    num_instructions_to_generate: int [Default: 2.0]
 #    repo_branch: str
 #    repo_pr: int
 #    repo_url: str [Default: 'https://github.com/instructlab/taxonomy.git']
+#    storage_class_name: str [Default: 'ocs-external-storagecluster-ceph-rbd']
 components:
+  comp-artifact-to-pvc-op:
+    executorLabel: exec-artifact-to-pvc-op
+    inputDefinitions:
+      artifacts:
+        data:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+      parameters:
+        pvc_path:
+          parameterType: STRING
+  comp-artifact-to-pvc-op-2:
+    executorLabel: exec-artifact-to-pvc-op-2
+    inputDefinitions:
+      artifacts:
+        data:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+      parameters:
+        pvc_path:
+          parameterType: STRING
+  comp-createpvc:
+    executorLabel: exec-createpvc
+    inputDefinitions:
+      parameters:
+        access_modes:
+          description: 'AccessModes to request for the provisioned PVC. May
+
+            be one or more of ``''ReadWriteOnce''``, ``''ReadOnlyMany''``, ``''ReadWriteMany''``,
+            or
+
+            ``''ReadWriteOncePod''``. Corresponds to `PersistentVolumeClaim.spec.accessModes
+            <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`_.'
+          parameterType: LIST
+        annotations:
+          description: Annotations for the PVC's metadata. Corresponds to `PersistentVolumeClaim.metadata.annotations
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+          isOptional: true
+          parameterType: STRUCT
+        pvc_name:
+          description: 'Name of the PVC. Corresponds to `PersistentVolumeClaim.metadata.name
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+            Only one of ``pvc_name`` and ``pvc_name_suffix`` can
+
+            be provided.'
+          isOptional: true
+          parameterType: STRING
+        pvc_name_suffix:
+          description: 'Prefix to use for a dynamically generated name, which
+
+            will take the form ``<argo-workflow-name>-<pvc_name_suffix>``. Only one
+
+            of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
+          isOptional: true
+          parameterType: STRING
+        size:
+          description: The size of storage requested by the PVC that will be provisioned.
+            For example, ``'5Gi'``. Corresponds to `PersistentVolumeClaim.spec.resources.requests.storage
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.
+          parameterType: STRING
+        storage_class_name:
+          defaultValue: ''
+          description: 'Name of StorageClass from which to provision the PV
+
+            to back the PVC. ``None`` indicates to use the cluster''s default
+
+            storage_class_name. Set to ``''''`` for a statically specified PVC.'
+          isOptional: true
+          parameterType: STRING
+        volume_name:
+          description: 'Pre-existing PersistentVolume that should back the
+
+            provisioned PersistentVolumeClaim. Used for statically
+
+            specified PV only. Corresponds to `PersistentVolumeClaim.spec.volumeName
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
+          isOptional: true
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        name:
+          parameterType: STRING
+  comp-createpvc-2:
+    executorLabel: exec-createpvc-2
+    inputDefinitions:
+      parameters:
+        access_modes:
+          description: 'AccessModes to request for the provisioned PVC. May
+
+            be one or more of ``''ReadWriteOnce''``, ``''ReadOnlyMany''``, ``''ReadWriteMany''``,
+            or
+
+            ``''ReadWriteOncePod''``. Corresponds to `PersistentVolumeClaim.spec.accessModes
+            <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`_.'
+          parameterType: LIST
+        annotations:
+          description: Annotations for the PVC's metadata. Corresponds to `PersistentVolumeClaim.metadata.annotations
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+          isOptional: true
+          parameterType: STRUCT
+        pvc_name:
+          description: 'Name of the PVC. Corresponds to `PersistentVolumeClaim.metadata.name
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+            Only one of ``pvc_name`` and ``pvc_name_suffix`` can
+
+            be provided.'
+          isOptional: true
+          parameterType: STRING
+        pvc_name_suffix:
+          description: 'Prefix to use for a dynamically generated name, which
+
+            will take the form ``<argo-workflow-name>-<pvc_name_suffix>``. Only one
+
+            of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
+          isOptional: true
+          parameterType: STRING
+        size:
+          description: The size of storage requested by the PVC that will be provisioned.
+            For example, ``'5Gi'``. Corresponds to `PersistentVolumeClaim.spec.resources.requests.storage
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.
+          parameterType: STRING
+        storage_class_name:
+          defaultValue: ''
+          description: 'Name of StorageClass from which to provision the PV
+
+            to back the PVC. ``None`` indicates to use the cluster''s default
+
+            storage_class_name. Set to ``''''`` for a statically specified PVC.'
+          isOptional: true
+          parameterType: STRING
+        volume_name:
+          description: 'Pre-existing PersistentVolume that should back the
+
+            provisioned PersistentVolumeClaim. Used for statically
+
+            specified PV only. Corresponds to `PersistentVolumeClaim.spec.volumeName
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
+          isOptional: true
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        name:
+          parameterType: STRING
+  comp-createpvc-3:
+    executorLabel: exec-createpvc-3
+    inputDefinitions:
+      parameters:
+        access_modes:
+          description: 'AccessModes to request for the provisioned PVC. May
+
+            be one or more of ``''ReadWriteOnce''``, ``''ReadOnlyMany''``, ``''ReadWriteMany''``,
+            or
+
+            ``''ReadWriteOncePod''``. Corresponds to `PersistentVolumeClaim.spec.accessModes
+            <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`_.'
+          parameterType: LIST
+        annotations:
+          description: Annotations for the PVC's metadata. Corresponds to `PersistentVolumeClaim.metadata.annotations
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+          isOptional: true
+          parameterType: STRUCT
+        pvc_name:
+          description: 'Name of the PVC. Corresponds to `PersistentVolumeClaim.metadata.name
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaim>`_.
+            Only one of ``pvc_name`` and ``pvc_name_suffix`` can
+
+            be provided.'
+          isOptional: true
+          parameterType: STRING
+        pvc_name_suffix:
+          description: 'Prefix to use for a dynamically generated name, which
+
+            will take the form ``<argo-workflow-name>-<pvc_name_suffix>``. Only one
+
+            of ``pvc_name`` and ``pvc_name_suffix`` can be provided.'
+          isOptional: true
+          parameterType: STRING
+        size:
+          description: The size of storage requested by the PVC that will be provisioned.
+            For example, ``'5Gi'``. Corresponds to `PersistentVolumeClaim.spec.resources.requests.storage
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.
+          parameterType: STRING
+        storage_class_name:
+          defaultValue: ''
+          description: 'Name of StorageClass from which to provision the PV
+
+            to back the PVC. ``None`` indicates to use the cluster''s default
+
+            storage_class_name. Set to ``''''`` for a statically specified PVC.'
+          isOptional: true
+          parameterType: STRING
+        volume_name:
+          description: 'Pre-existing PersistentVolume that should back the
+
+            provisioned PersistentVolumeClaim. Used for statically
+
+            specified PV only. Corresponds to `PersistentVolumeClaim.spec.volumeName
+            <https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#PersistentVolumeClaimSpec>`_.'
+          isOptional: true
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        name:
+          parameterType: STRING
+  comp-deletepvc:
+    executorLabel: exec-deletepvc
+    inputDefinitions:
+      parameters:
+        pvc_name:
+          description: Name of the PVC to delete. Supports passing a runtime-generated
+            name, such as a name provided by ``kubernetes.CreatePvcOp().outputs['name']``.
+          parameterType: STRING
+  comp-deletepvc-2:
+    executorLabel: exec-deletepvc-2
+    inputDefinitions:
+      parameters:
+        pvc_name:
+          description: Name of the PVC to delete. Supports passing a runtime-generated
+            name, such as a name provided by ``kubernetes.CreatePvcOp().outputs['name']``.
+          parameterType: STRING
+  comp-deletepvc-3:
+    executorLabel: exec-deletepvc-3
+    inputDefinitions:
+      parameters:
+        pvc_name:
+          description: Name of the PVC to delete. Supports passing a runtime-generated
+            name, such as a name provided by ``kubernetes.CreatePvcOp().outputs['name']``.
+          parameterType: STRING
   comp-git-clone-op:
     executorLabel: exec-git-clone-op
     inputDefinitions:
@@ -23,6 +254,76 @@ components:
           artifactType:
             schemaTitle: system.Dataset
             schemaVersion: 0.0.1
+  comp-huggingface-importer-op:
+    executorLabel: exec-huggingface-importer-op
+    inputDefinitions:
+      parameters:
+        repo_name:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        model:
+          artifactType:
+            schemaTitle: system.Model
+            schemaVersion: 0.0.1
+  comp-kubectl-apply-op:
+    executorLabel: exec-kubectl-apply-op
+    inputDefinitions:
+      parameters:
+        manifest:
+          parameterType: STRING
+  comp-kubectl-wait-for-op:
+    executorLabel: exec-kubectl-wait-for-op
+    inputDefinitions:
+      parameters:
+        condition:
+          parameterType: STRING
+        kind:
+          parameterType: STRING
+        name:
+          parameterType: STRING
+  comp-pvc-to-artifact-op:
+    executorLabel: exec-pvc-to-artifact-op
+    inputDefinitions:
+      parameters:
+        pvc_path:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        model:
+          artifactType:
+            schemaTitle: system.Artifact
+            schemaVersion: 0.0.1
+  comp-pvc-to-model-op:
+    executorLabel: exec-pvc-to-model-op
+    inputDefinitions:
+      parameters:
+        pvc_path:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        model:
+          artifactType:
+            schemaTitle: system.Model
+            schemaVersion: 0.0.1
+  comp-pytorchjob-manifest-op:
+    executorLabel: exec-pytorchjob-manifest-op
+    inputDefinitions:
+      parameters:
+        input_pvc_name:
+          parameterType: STRING
+        model_pvc_name:
+          parameterType: STRING
+        name_suffix:
+          parameterType: STRING
+        output_pvc_name:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        manifest:
+          parameterType: STRING
+        name:
+          parameterType: STRING
   comp-sdg-op:
     executorLabel: exec-sdg-op
     inputDefinitions:
@@ -46,6 +347,40 @@ components:
             schemaVersion: 0.0.1
 deploymentSpec:
   executors:
+    exec-artifact-to-pvc-op:
+      container:
+        args:
+        - cp -r {{$.inputs.artifacts['data'].path}} {{$.inputs.parameters['pvc_path']}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
+    exec-artifact-to-pvc-op-2:
+      container:
+        args:
+        - cp -r {{$.inputs.artifacts['data'].path}} {{$.inputs.parameters['pvc_path']}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
+    exec-createpvc:
+      container:
+        image: argostub/createpvc
+    exec-createpvc-2:
+      container:
+        image: argostub/createpvc
+    exec-createpvc-3:
+      container:
+        image: argostub/createpvc
+    exec-deletepvc:
+      container:
+        image: argostub/deletepvc
+    exec-deletepvc-2:
+      container:
+        image: argostub/deletepvc
+    exec-deletepvc-3:
+      container:
+        image: argostub/deletepvc
     exec-git-clone-op:
       container:
         args:
@@ -59,6 +394,158 @@ deploymentSpec:
         - /bin/sh
         - -c
         image: registry.access.redhat.com/ubi9/toolbox
+    exec-huggingface-importer-op:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - huggingface_importer_op
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
+          \  python3 -m pip install --quiet --no-warn-script-location 'huggingface_hub'\
+          \ && \"$0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef huggingface_importer_op(model: dsl.Output[dsl.Model], repo_name:\
+          \ str):\n    from huggingface_hub import snapshot_download\n\n    snapshot_download(repo_id=repo_name,\
+          \ cache_dir=\"/tmp\", local_dir=model.path)\n\n"
+        image: registry.access.redhat.com/ubi9/python-311:latest
+    exec-kubectl-apply-op:
+      container:
+        args:
+        - echo "{{$.inputs.parameters['manifest']}}" | kubectl apply -f -
+        command:
+        - /bin/sh
+        - -c
+        image: registry.redhat.io/openshift4/ose-cli
+    exec-kubectl-wait-for-op:
+      container:
+        args:
+        - kubectl wait --for={{$.inputs.parameters['condition']}} {{$.inputs.parameters['kind']}}/{{$.inputs.parameters['name']}}
+          --timeout=2h
+        command:
+        - /bin/sh
+        - -c
+        image: registry.redhat.io/openshift4/ose-cli
+    exec-pvc-to-artifact-op:
+      container:
+        args:
+        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['model'].path}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
+    exec-pvc-to-model-op:
+      container:
+        args:
+        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['model'].path}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
+    exec-pytorchjob-manifest-op:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - pytorchjob_manifest_op
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef pytorchjob_manifest_op(\n    model_pvc_name: str,\n    input_pvc_name:\
+          \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n) -> NamedTuple(\"\
+          outputs\", manifest=str, name=str):\n    import inspect\n\n    Outputs =\
+          \ NamedTuple(\"outputs\", manifest=str, name=str)\n    name = f\"train-{name_suffix.rstrip('-sdg')}\"\
+          \n\n    image = 'quay.io/tcoufal/ilab-train:latest'\n\n    manifest = inspect.cleandoc(\n\
+          \        f\"\"\"\n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n\
+          \        metadata:\n          name: {name}\n        spec:\n          pytorchReplicaSpecs:\n\
+          \            Master:\n              replicas: 1\n              restartPolicy:\
+          \ OnFailure\n              template:\n                metadata:\n      \
+          \            annotations:\n                    sidecar.istio.io/inject:\
+          \ 'false'\n                spec:\n                  containers:\n      \
+          \              - args:\n                        - |\n                  \
+          \        mkdir /output/model;\n                          mkdir /output/data;\n\
+          \                          python3.11 -u run.py --nnodes 2 --nproc_per_node\
+          \ 2 --node_rank \"$(RANK)\" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT)\
+          \ --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl\
+          \ --ckpt_output_dir /output/model --data_output_dir /output/data\n     \
+          \                 command:\n                        - /bin/bash\n      \
+          \                  - '-c'\n                        - '--'\n            \
+          \          image: {image}\n                      name: pytorch\n       \
+          \               volumeMounts:\n                        - mountPath: /input_data\n\
+          \                          name: input-data\n                          readOnly:\
+          \ true\n                        - mountPath: /input_model\n            \
+          \              name: model\n                          readOnly: true\n \
+          \                       - mountPath: /output\n                         \
+          \ name: output\n                      resources:\n                     \
+          \   requests:\n                          memory: 8Gi\n                 \
+          \         cpu: 2\n                          \"nvidia.com/gpu\": 1\n    \
+          \                    limits:\n                          memory: 8Gi\n  \
+          \                        cpu: 2\n                          \"nvidia.com/gpu\"\
+          : 1\n                  volumes:\n                    - name: input-data\n\
+          \                      persistentVolumeClaim:\n                        claimName:\
+          \ {input_pvc_name}\n                    - name: model\n                \
+          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
+          \                    - name: output\n                      persistentVolumeClaim:\n\
+          \                        claimName: {output_pvc_name}\n            Worker:\n\
+          \              replicas: 1\n              restartPolicy: OnFailure\n   \
+          \           template:\n                metadata:\n                  annotations:\n\
+          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
+          \                  containers:\n                    - args:\n          \
+          \              - |\n                          python3.11 -u run.py --nnodes\
+          \ 2 --nproc_per_node 2 --node_rank \"$(RANK)\" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT)\
+          \ --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl\
+          \ --ckpt_output_dir /tmp/model --data_output_dir /tmp/data\n           \
+          \           command:\n                        - /bin/bash\n            \
+          \            - '-c'\n                        - '--'\n                  \
+          \    image: {image}\n                      name: pytorch\n             \
+          \         volumeMounts:\n                        - mountPath: /input_data\n\
+          \                          name: input-data\n                          readOnly:\
+          \ true\n                        - mountPath: /input_model\n            \
+          \              name: model\n                          readOnly: true\n \
+          \                     resources:\n                        requests:\n  \
+          \                        memory: 8Gi\n                          cpu: 2\n\
+          \                          \"nvidia.com/gpu\": 1\n                     \
+          \   limits:\n                          memory: 8Gi\n                   \
+          \       cpu: 2\n                          \"nvidia.com/gpu\": 1\n      \
+          \            volumes:\n                    - name: input-data\n        \
+          \              persistentVolumeClaim:\n                        claimName:\
+          \ {input_pvc_name}\n                    - name: model\n                \
+          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
+          \        \"\"\"\n    )\n\n    return Outputs(manifest, name)\n\n"
+        image: registry.access.redhat.com/ubi9/python-311:latest
     exec-sdg-op:
       container:
         args:
@@ -108,6 +595,156 @@ pipelineInfo:
 root:
   dag:
     tasks:
+      artifact-to-pvc-op:
+        cachingOptions: {}
+        componentRef:
+          name: comp-artifact-to-pvc-op
+        dependentTasks:
+        - createpvc
+        - huggingface-importer-op
+        inputs:
+          artifacts:
+            data:
+              taskOutputArtifact:
+                outputArtifactKey: model
+                producerTask: huggingface-importer-op
+          parameters:
+            pvc_path:
+              runtimeValue:
+                constant: /model
+        taskInfo:
+          name: artifact-to-pvc-op
+      artifact-to-pvc-op-2:
+        cachingOptions: {}
+        componentRef:
+          name: comp-artifact-to-pvc-op-2
+        dependentTasks:
+        - createpvc-2
+        - sdg-op
+        inputs:
+          artifacts:
+            data:
+              taskOutputArtifact:
+                outputArtifactKey: sdg
+                producerTask: sdg-op
+          parameters:
+            pvc_path:
+              runtimeValue:
+                constant: /data
+        taskInfo:
+          name: artifact-to-pvc-op-2
+      createpvc:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-createpvc
+        inputs:
+          parameters:
+            access_modes:
+              runtimeValue:
+                constant:
+                - ReadWriteOnce
+            pvc_name_suffix:
+              runtimeValue:
+                constant: -model-cache
+            size:
+              runtimeValue:
+                constant: 50Gi
+            storage_class_name:
+              componentInputParameter: storage_class_name
+        taskInfo:
+          name: createpvc
+      createpvc-2:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-createpvc-2
+        inputs:
+          parameters:
+            access_modes:
+              runtimeValue:
+                constant:
+                - ReadWriteOnce
+            pvc_name_suffix:
+              runtimeValue:
+                constant: -sdg
+            size:
+              runtimeValue:
+                constant: 1Gi
+            storage_class_name:
+              componentInputParameter: storage_class_name
+        taskInfo:
+          name: createpvc-2
+      createpvc-3:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-createpvc-3
+        inputs:
+          parameters:
+            access_modes:
+              runtimeValue:
+                constant:
+                - ReadWriteOnce
+            pvc_name_suffix:
+              runtimeValue:
+                constant: -output
+            size:
+              runtimeValue:
+                constant: 50Gi
+            storage_class_name:
+              componentInputParameter: storage_class_name
+        taskInfo:
+          name: createpvc-3
+      deletepvc:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-deletepvc
+        dependentTasks:
+        - createpvc-2
+        - kubectl-wait-for-op
+        inputs:
+          parameters:
+            pvc_name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc-2
+        taskInfo:
+          name: deletepvc
+      deletepvc-2:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-deletepvc-2
+        dependentTasks:
+        - createpvc
+        - kubectl-wait-for-op
+        inputs:
+          parameters:
+            pvc_name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc
+        taskInfo:
+          name: deletepvc-2
+      deletepvc-3:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-deletepvc-3
+        dependentTasks:
+        - createpvc-3
+        - pvc-to-artifact-op
+        - pvc-to-model-op
+        inputs:
+          parameters:
+            pvc_name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc-3
+        taskInfo:
+          name: deletepvc-3
       git-clone-op:
         cachingOptions:
           enableCache: true
@@ -123,6 +760,110 @@ root:
               componentInputParameter: repo_url
         taskInfo:
           name: git-clone-op
+      huggingface-importer-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-huggingface-importer-op
+        inputs:
+          parameters:
+            repo_name:
+              componentInputParameter: base_model
+        taskInfo:
+          name: huggingface-importer-op
+      kubectl-apply-op:
+        cachingOptions: {}
+        componentRef:
+          name: comp-kubectl-apply-op
+        dependentTasks:
+        - artifact-to-pvc-op
+        - artifact-to-pvc-op-2
+        - pytorchjob-manifest-op
+        inputs:
+          parameters:
+            manifest:
+              taskOutputParameter:
+                outputParameterKey: manifest
+                producerTask: pytorchjob-manifest-op
+        taskInfo:
+          name: kubectl-apply-op
+      kubectl-wait-for-op:
+        cachingOptions: {}
+        componentRef:
+          name: comp-kubectl-wait-for-op
+        dependentTasks:
+        - kubectl-apply-op
+        - pytorchjob-manifest-op
+        inputs:
+          parameters:
+            condition:
+              runtimeValue:
+                constant: condition=Succeeded
+            kind:
+              runtimeValue:
+                constant: pytorchjobs
+            name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: pytorchjob-manifest-op
+        taskInfo:
+          name: kubectl-wait-for-op
+      pvc-to-artifact-op:
+        cachingOptions: {}
+        componentRef:
+          name: comp-pvc-to-artifact-op
+        dependentTasks:
+        - kubectl-wait-for-op
+        inputs:
+          parameters:
+            pvc_path:
+              runtimeValue:
+                constant: /output/data
+        taskInfo:
+          name: pvc-to-artifact-op
+      pvc-to-model-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-pvc-to-model-op
+        dependentTasks:
+        - kubectl-wait-for-op
+        inputs:
+          parameters:
+            pvc_path:
+              runtimeValue:
+                constant: /output/model
+        taskInfo:
+          name: pvc-to-model-op
+      pytorchjob-manifest-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-pytorchjob-manifest-op
+        dependentTasks:
+        - createpvc
+        - createpvc-2
+        - createpvc-3
+        inputs:
+          parameters:
+            input_pvc_name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc-2
+            model_pvc_name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc
+            name_suffix:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc-2
+            output_pvc_name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc-3
+        taskInfo:
+          name: pytorchjob-manifest-op
       sdg-op:
         cachingOptions:
           enableCache: true
@@ -147,6 +888,10 @@ root:
           name: sdg-op
   inputDefinitions:
     parameters:
+      base_model:
+        defaultValue: ibm-granite/granite-7b-base
+        isOptional: true
+        parameterType: STRING
       num_instructions_to_generate:
         defaultValue: 2.0
         isOptional: true
@@ -161,6 +906,10 @@ root:
         defaultValue: https://github.com/instructlab/taxonomy.git
         isOptional: true
         parameterType: STRING
+      storage_class_name:
+        defaultValue: ocs-external-storagecluster-ceph-rbd
+        isOptional: true
+        parameterType: STRING
 schemaVersion: 2.1.0
 sdkVersion: kfp-2.8.0
 ---
@@ -168,6 +917,18 @@ platforms:
   kubernetes:
     deploymentSpec:
       executors:
+        exec-artifact-to-pvc-op:
+          pvcMount:
+          - mountPath: /model
+            taskOutputParameter:
+              outputParameterKey: name
+              producerTask: createpvc
+        exec-artifact-to-pvc-op-2:
+          pvcMount:
+          - mountPath: /data
+            taskOutputParameter:
+              outputParameterKey: name
+              producerTask: createpvc-2
         exec-sdg-op:
           configMapAsEnv:
           - configMapName: kfp-model-server

--- a/sdg/faked/components.py
+++ b/sdg/faked/components.py
@@ -2,10 +2,9 @@
 # pylint: disable=unused-argument
 from typing import Optional
 from kfp import dsl
+from utils.consts import PYTHON_IMAGE
 
-IMAGE = "registry.access.redhat.com/ubi9/python-311:latest"
-
-@dsl.component(base_image=IMAGE)
+@dsl.component(base_image=PYTHON_IMAGE)
 def git_clone_op(
     taxonomy: dsl.Output[dsl.Dataset],
     repo_branch: str,
@@ -15,7 +14,7 @@ def git_clone_op(
     return
 
 
-@dsl.component(base_image=IMAGE, packages_to_install=["git+https://github.com/redhat-et/ilab-on-ocp.git#subdirectory=sdg/faked/fixtures"])
+@dsl.component(base_image=PYTHON_IMAGE, packages_to_install=["git+https://github.com/redhat-et/ilab-on-ocp.git#subdirectory=sdg/faked/fixtures"])
 def sdg_op(
     num_instructions_to_generate: int,
     taxonomy: dsl.Input[dsl.Dataset],

--- a/training/Containerfile
+++ b/training/Containerfile
@@ -18,6 +18,14 @@ RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/python3.11/site-pack
     && python3.11 -m pip install packaging wheel setuptools-scm \
     && python3.11 -m pip install --no-cache-dir "instructlab-training[cuda]@git+https://github.com/instructlab/training.git"
 
+# We don't expect to keep Triton cache after pod is finished
+ENV TRITON_CACHE_DIR="/tmp"
+
+# Set HF_HOME to volatile location. We do not preserve cache etc over restarts with this container.
+# https://huggingface.co/docs/huggingface_hub/en/guides/manage-cache
+ENV HF_HOME="/tmp"
+ENV TRANSFORMERS_CACHE="/tmp"
+
 COPY run.py .
 
 USER 1001

--- a/training/Containerfile
+++ b/training/Containerfile
@@ -1,16 +1,24 @@
 FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubi9
+
 RUN dnf install -y python3.11 python3.11-devel git python3-pip make automake gcc gcc-c++ \
     && dnf clean all \
     && rm -rf /var/cache/*dnf*
-WORKDIR /instructlab
-RUN python3.11 -m ensurepip
-RUN git clone https://github.com/instructlab/training.git
-RUN python3.11 -m pip install -e ./training
-RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib" \
-    && python3.11 -m pip install -e ./training[cuda]
+
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib"
-COPY run.py .
-ENV HOME=/instructlab
-RUN chmod -R 777 /instructlab
-USER 1001
+
 ENTRYPOINT ["/bin/bash"]
+
+# FIXME: pip install instructlab-trainin[cuda] is problematic atm:
+# https://github.com/instructlab/training/issues/147
+# https://github.com/instructlab/instructlab/issues/1864
+RUN export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib/python3.11/site-packages/nvidia/cudnn/lib" \
+    && python3.11 -m ensurepip \
+    && python3.11 -m pip install --no-cache-dir --upgrade pip \
+    && CMAKE_ARGS="-DLLAMA_CUDA=on" python3.11 -m pip install "instructlab-training@git+https://github.com/instructlab/training.git" \
+    && python3.11 -m pip install packaging wheel setuptools-scm \
+    && python3.11 -m pip install --no-cache-dir "instructlab-training[cuda]@git+https://github.com/instructlab/training.git"
+
+COPY run.py .
+
+USER 1001
+

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,0 +1,4 @@
+from .components import pytorchjob_manifest_op
+from . import faked
+
+__all__ = ["pytorchjob_manifest_op", "faked"]

--- a/training/components.py
+++ b/training/components.py
@@ -29,7 +29,7 @@ def pytorchjob_manifest_op(
         metadata:
           name: {name}
         spec:
-          nprocPerNode: "{nprocPerNode}"
+          nprocPerNode: \\"{nprocPerNode}\\"
           pytorchReplicaSpecs:
             Master:
               replicas: 1
@@ -44,7 +44,7 @@ def pytorchjob_manifest_op(
                         - |
                           mkdir -p /output/model;
                           mkdir -p /output/data;
-                          python3.11 -u run.py --nnodes {nnodes} --nproc_per_node {nprocPerNode} --node_rank \\$RANK --rdzv_endpoint \\$MASTER_ADDR:\\$MASTER_PORT --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl --ckpt_output_dir /output/model --data_output_dir /output/data
+                          python3.11 -u run.py --model_path /input_model/model --data_path /input_data/sdg/*_train_msgs*.jsonl --ckpt_output_dir /output/model --data_output_dir /output/data
                       command:
                         - /bin/bash
                         - '-c'
@@ -60,6 +60,11 @@ def pytorchjob_manifest_op(
                           readOnly: true
                         - mountPath: /output
                           name: output
+                      env:
+                        - name: NNODES
+                          value: \\"{nnodes}\\"
+                        - name: NPROC_PER_NODE
+                          value: \\"{nprocPerNode}\\"
                       resources:
                         requests:
                           memory: 8Gi
@@ -90,7 +95,9 @@ def pytorchjob_manifest_op(
                   containers:
                     - args:
                         - |
-                          python3.11 -u run.py --nnodes {nnodes} --nproc_per_node {nprocPerNode}  --node_rank \\$RANK --rdzv_endpoint \\$MASTER_ADDR:\\$MASTER_PORT --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl --ckpt_output_dir /tmp/model --data_output_dir /tmp/data
+                          mkdir -p /output/model;
+                          mkdir -p /output/data;
+                          python3.11 -u run.py --model_path /input_model/model --data_path /input_data/sdg/*_train_msgs*.jsonl --ckpt_output_dir /tmp/model --data_output_dir /tmp/data
                       command:
                         - /bin/bash
                         - '-c'
@@ -104,6 +111,11 @@ def pytorchjob_manifest_op(
                         - mountPath: /input_model
                           name: model
                           readOnly: true
+                      env:
+                        - name: NNODES
+                          value: \\"{nnodes}\\"
+                        - name: NPROC_PER_NODE
+                          value: \\"{nprocPerNode}\\"
                       resources:
                         requests:
                           memory: 8Gi

--- a/training/components.py
+++ b/training/components.py
@@ -1,0 +1,123 @@
+# type: ignore
+# pylint: disable=import-outside-toplevel,missing-function-docstring
+
+from kfp import dsl
+from typing import NamedTuple
+from utils.consts import PYTHON_IMAGE
+
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def pytorchjob_manifest_op(
+    model_pvc_name: str,
+    input_pvc_name: str,
+    output_pvc_name: str,
+    name_suffix: str,
+) -> NamedTuple("outputs", manifest=str, name=str):
+    import inspect
+
+    Outputs = NamedTuple("outputs", manifest=str, name=str)
+    name = f"train-{name_suffix.rstrip('-sdg')}"
+
+    image = 'quay.io/tcoufal/ilab-train:latest'
+
+    manifest = inspect.cleandoc(
+        f"""
+        apiVersion: kubeflow.org/v1
+        kind: PyTorchJob
+        metadata:
+          name: {name}
+        spec:
+          pytorchReplicaSpecs:
+            Master:
+              replicas: 1
+              restartPolicy: OnFailure
+              template:
+                metadata:
+                  annotations:
+                    sidecar.istio.io/inject: 'false'
+                spec:
+                  containers:
+                    - args:
+                        - |
+                          mkdir /output/model;
+                          mkdir /output/data;
+                          python3.11 -u run.py --nnodes 2 --nproc_per_node 2 --node_rank "$(RANK)" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT) --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl --ckpt_output_dir /output/model --data_output_dir /output/data
+                      command:
+                        - /bin/bash
+                        - '-c'
+                        - '--'
+                      image: {image}
+                      name: pytorch
+                      volumeMounts:
+                        - mountPath: /input_data
+                          name: input-data
+                          readOnly: true
+                        - mountPath: /input_model
+                          name: model
+                          readOnly: true
+                        - mountPath: /output
+                          name: output
+                      resources:
+                        requests:
+                          memory: 8Gi
+                          cpu: 2
+                          "nvidia.com/gpu": 1
+                        limits:
+                          memory: 8Gi
+                          cpu: 2
+                          "nvidia.com/gpu": 1
+                  volumes:
+                    - name: input-data
+                      persistentVolumeClaim:
+                        claimName: {input_pvc_name}
+                    - name: model
+                      persistentVolumeClaim:
+                        claimName: {model_pvc_name}
+                    - name: output
+                      persistentVolumeClaim:
+                        claimName: {output_pvc_name}
+            Worker:
+              replicas: 1
+              restartPolicy: OnFailure
+              template:
+                metadata:
+                  annotations:
+                    sidecar.istio.io/inject: 'false'
+                spec:
+                  containers:
+                    - args:
+                        - |
+                          python3.11 -u run.py --nnodes 2 --nproc_per_node 2 --node_rank "$(RANK)" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT) --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl --ckpt_output_dir /tmp/model --data_output_dir /tmp/data
+                      command:
+                        - /bin/bash
+                        - '-c'
+                        - '--'
+                      image: {image}
+                      name: pytorch
+                      volumeMounts:
+                        - mountPath: /input_data
+                          name: input-data
+                          readOnly: true
+                        - mountPath: /input_model
+                          name: model
+                          readOnly: true
+                      resources:
+                        requests:
+                          memory: 8Gi
+                          cpu: 2
+                          "nvidia.com/gpu": 1
+                        limits:
+                          memory: 8Gi
+                          cpu: 2
+                          "nvidia.com/gpu": 1
+                  volumes:
+                    - name: input-data
+                      persistentVolumeClaim:
+                        claimName: {input_pvc_name}
+                    - name: model
+                      persistentVolumeClaim:
+                        claimName: {model_pvc_name}
+        """
+    )
+
+    return Outputs(manifest, name)

--- a/training/components.py
+++ b/training/components.py
@@ -20,7 +20,7 @@ def pytorchjob_manifest_op(
 
     image = 'quay.io/tcoufal/ilab-train:latest'
     nprocPerNode = 2
-    nnodes = 2
+    nnodes = 1
 
     manifest = inspect.cleandoc(
         f"""

--- a/training/components.py
+++ b/training/components.py
@@ -39,8 +39,8 @@ def pytorchjob_manifest_op(
                   containers:
                     - args:
                         - |
-                          mkdir /output/model;
-                          mkdir /output/data;
+                          mkdir -p /output/model;
+                          mkdir -p /output/data;
                           python3.11 -u run.py --nnodes 2 --nproc_per_node 2 --node_rank "$(RANK)" --rdzv_endpoint $(MASTER_ADDR):$(MASTER_PORT) --model_path /input_model --data_path /input_data/*_train_msgs*.jsonl --ckpt_output_dir /output/model --data_output_dir /output/data
                       command:
                         - /bin/bash

--- a/training/components.py
+++ b/training/components.py
@@ -67,11 +67,9 @@ def pytorchjob_manifest_op(
                           value: \\"{nprocPerNode}\\"
                       resources:
                         requests:
-                          memory: 8Gi
                           cpu: 2
                           "nvidia.com/gpu": {nprocPerNode}
                         limits:
-                          memory: 8Gi
                           cpu: 2
                           "nvidia.com/gpu": {nprocPerNode}
                   volumes:
@@ -118,11 +116,9 @@ def pytorchjob_manifest_op(
                           value: \\"{nprocPerNode}\\"
                       resources:
                         requests:
-                          memory: 8Gi
                           cpu: 2
                           "nvidia.com/gpu": {nprocPerNode}
                         limits:
-                          memory: 8Gi
                           cpu: 2
                           "nvidia.com/gpu": {nprocPerNode}
                   volumes:

--- a/training/faked/__init__.py
+++ b/training/faked/__init__.py
@@ -1,0 +1,3 @@
+from .components import pytorchjob_manifest_op
+
+__all__ = ["pytorchjob_manifest_op"]

--- a/training/faked/components.py
+++ b/training/faked/components.py
@@ -1,0 +1,17 @@
+# type: ignore
+# pylint: disable=import-outside-toplevel,missing-function-docstring,unused-argument
+
+from kfp import dsl
+from typing import NamedTuple
+from utils.consts import PYTHON_IMAGE
+
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def pytorchjob_manifest_op(
+    model_pvc_name: str,
+    input_pvc_name: str,
+    output_pvc_name: str,
+    name_suffix: str,
+) -> NamedTuple("outputs", manifest=str, name=str):
+    Outputs = NamedTuple("outputs", manifest=str, name=str)
+    return Outputs("", "")

--- a/training/run.py
+++ b/training/run.py
@@ -27,11 +27,11 @@ parser.add_argument("--random_seed", default=42)
 parser.add_argument("--checkpoint_at_epoch", default=True)
 
 # Torchrun Args
-parser.add_argument("--nnodes", default=1)
-parser.add_argument("--nproc_per_node", default=1)
-parser.add_argument("--node_rank", default=0)
+parser.add_argument("--nnodes", default=os.getenv("NNODES", "1"))
+parser.add_argument("--nproc_per_node", default=os.getenv("NPROC_PER_NODE", "1"))
+parser.add_argument("--node_rank", default=os.getenv("RANK"))
 parser.add_argument("--rdzv_id", default=123)
-parser.add_argument("--rdzv_endpoint", default= "127.0.0.1:12345")
+parser.add_argument("--rdzv_endpoint", default=f"{os.getenv('MASTER_ADDR', '127.0.0.1')}:{os.getenv('MASTER_PORT','12345')}")
 
 args = parser.parse_args()
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,19 @@
+from .components import (
+    kubectl_apply_op,
+    kubectl_wait_for_op,
+    artifact_to_pvc_op,
+    huggingface_importer_op,
+    pvc_to_artifact_op,
+    pvc_to_model_op,
+)
+from . import faked
+
+__all__ = [
+    "kubectl_apply_op",
+    "kubectl_wait_for_op",
+    "artifact_to_pvc_op",
+    "huggingface_importer_op",
+    "pvc_to_artifact_op",
+    "pvc_to_model_op",
+    "faked",
+]

--- a/utils/components.py
+++ b/utils/components.py
@@ -1,0 +1,64 @@
+# type: ignore
+# pylint: disable=no-value-for-parameter,import-outside-toplevel,import-error,no-member,missing-function-docstring
+from kfp import dsl
+from .consts import OC_IMAGE, PYTHON_IMAGE, TOOLBOX_IMAGE
+
+
+@dsl.container_component
+def kubectl_apply_op(manifest: str):
+    return dsl.ContainerSpec(
+        OC_IMAGE,
+        ["/bin/sh", "-c"],
+        [f'echo "{manifest}" | kubectl apply -f -'],
+    )
+
+
+@dsl.container_component
+def kubectl_wait_for_op(
+    condition: str,
+    kind: str,
+    name: str,
+    # namespace: Optional[str] = None,
+    # timeout: Optional[str] = None,
+):
+    return dsl.ContainerSpec(
+        OC_IMAGE,
+        ["/bin/sh", "-c"],
+        [
+            f"kubectl wait --for={condition} {kind}/{name} --timeout=2h",
+        ],
+    )
+
+
+@dsl.container_component
+def artifact_to_pvc_op(data: dsl.Input[dsl.Artifact], pvc_path: str):
+    return dsl.ContainerSpec(
+        TOOLBOX_IMAGE,
+        ["/bin/sh", "-c"],
+        [f"cp -r {data.path} {pvc_path}"],
+    )
+
+
+@dsl.container_component
+def pvc_to_artifact_op(model: dsl.Output[dsl.Artifact], pvc_path: str):
+    return dsl.ContainerSpec(
+        TOOLBOX_IMAGE,
+        ["/bin/sh", "-c"],
+        [f"cp -r {pvc_path} {model.path}"],
+    )
+
+
+@dsl.container_component
+def pvc_to_model_op(model: dsl.Output[dsl.Model], pvc_path: str):
+    return dsl.ContainerSpec(
+        TOOLBOX_IMAGE,
+        ["/bin/sh", "-c"],
+        [f"cp -r {pvc_path} {model.path}"],
+    )
+
+
+@dsl.component(base_image=PYTHON_IMAGE, packages_to_install=["huggingface_hub"])
+def huggingface_importer_op(model: dsl.Output[dsl.Model], repo_name: str):
+    from huggingface_hub import snapshot_download
+
+    snapshot_download(repo_id=repo_name, cache_dir="/tmp", local_dir=model.path)

--- a/utils/consts.py
+++ b/utils/consts.py
@@ -1,0 +1,3 @@
+PYTHON_IMAGE = "registry.access.redhat.com/ubi9/python-311:latest"
+TOOLBOX_IMAGE = "registry.access.redhat.com/ubi9/toolbox"
+OC_IMAGE = "registry.redhat.io/openshift4/ose-cli"

--- a/utils/faked/__init__.py
+++ b/utils/faked/__init__.py
@@ -1,0 +1,13 @@
+from .components import (
+    kubectl_apply_op,
+    kubectl_wait_for_op,
+    pvc_to_artifact_op,
+    pvc_to_model_op,
+)
+
+__all__ = [
+    "kubectl_apply_op",
+    "kubectl_wait_for_op",
+    "pvc_to_artifact_op",
+    "pvc_to_model_op",
+]

--- a/utils/faked/components.py
+++ b/utils/faked/components.py
@@ -1,0 +1,26 @@
+# type: ignore
+# pylint: disable=unused-argument,missing-function-docstring
+from kfp import dsl
+from ..consts import PYTHON_IMAGE
+
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def kubectl_apply_op(manifest: str):
+    return
+
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def kubectl_wait_for_op(condition: str, kind: str, name: str):
+    return
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def huggingface_importer_op(model: dsl.Output[dsl.Model], repo_name: str):
+    return
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def pvc_to_artifact_op(model: dsl.Output[dsl.Artifact], pvc_path: str):
+    return
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def pvc_to_model_op(model: dsl.Output[dsl.Model], pvc_path: str):
+    return


### PR DESCRIPTION
Competition PR to #14 

This bring Training stage to the pipeline

This is how it looks when run with faked SDG (I didn't want to wait for the PyTorchJob so I made it timeout on the wait step):

![image](https://github.com/user-attachments/assets/c1b3d7fc-3aaa-46cf-a0f3-6ebcc5e4d81d)


What works:
- Scheduling PyTorchJob
- Waiting for it
- Consuming SDG output and passing it to PVC
- Downloading base model from HuggingFace and storing it in Artifact
- Populating a PVC with base model
- Creating a PVC for output collection
- Collecting outputs from PVC into artifacts (Model + other outputs)
- Mounting all PVC to PyTorchJob

TODO:
- ~Fix passing data to PytorchJob, PVC requirement may not be the best option here~
- Fix `kubectl wait` to allow timeout/namespace params, I was initially not successful here due to some KFP templating issues...
- See if we can use something better for PyTorchJob `metadata.name` until `dsl.PIPELINE_*` is available (https://github.com/kubeflow/pipelines/issues/10453)
- See if we can do better than the storage class enforced by KFP: https://github.com/kubeflow/pipelines/blob/1cded35cf5e93d8c8d32fefbddceb2eed8de9a0a/backend/src/v2/driver/driver.go#L1428-L1436
- Add params/args everywhere for more customization