### PR TITLE
set XDG_CACHE to tmp

### DIFF
--- a/training/Containerfile
+++ b/training/Containerfile
@@ -25,6 +25,7 @@ ENV TRITON_CACHE_DIR="/tmp"
 # https://huggingface.co/docs/huggingface_hub/en/guides/manage-cache
 ENV HF_HOME="/tmp"
 ENV TRANSFORMERS_CACHE="/tmp"
+ENV XDG_CACHE_HOME="/tmp"
 
 COPY run.py .
 


### PR DESCRIPTION
During Training there is an error:
`[rank1]: PermissionError: [Errno 13] Permission denied: '/.cache'` as torch attempts to write to the .cache dir.

This PR updates the cache dir to `/tmp` to overcome this permission issue. 