### PR TITLE
Update training params for multi-node runs on MOC cluster

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -507,7 +507,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'instructlab-training@git+https://github.com/instructlab/training.git'\
           \ && \"$0\" \"$@\"\n"
@@ -589,7 +589,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'huggingface_hub'\
           \ && \"$0\" \"$@\"\n"
@@ -637,7 +637,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -697,7 +697,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -745,7 +745,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -763,22 +763,18 @@ deploymentSpec:
           \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n) -> NamedTuple(\"\
           outputs\", manifest=str, name=str):\n    import inspect\n\n    Outputs =\
           \ NamedTuple(\"outputs\", manifest=str, name=str)\n    name = f\"train-{name_suffix.rstrip('-sdg')}\"\
-          \n\n    image = 'quay.io/shanand/test-train:0.0.4'\n    nprocPerNode = 1\n\
-          \    nnodes = 2\n# (shanand): The master and the worker nodes have to be\
-          \ scheduled on a single OpenShift node for now. Once\n# the PVC issues are\
-          \ fixed this can be removed. Please \n# update the nodeSelector <NODE-NAME>\
-          \ before compiling the pipeline or else it'll break.\n    manifest = inspect.cleandoc(\n\
-          \        f\"\"\"\n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n\
-          \        metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
-          \ \\\\\"{nprocPerNode}\\\\\"\n          pytorchReplicaSpecs:\n         \
-          \   Master:\n              replicas: 1\n              restartPolicy: OnFailure\n\
-          \              template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  nodeSelector:\n                    kubernetes.io/hostname:\
-          \ <NODE-NAME>\n                  containers:\n                    - args:\n\
-          \                        - |\n                          mkdir -p /output/model;\n\
-          \                          mkdir -p /output/data;\n                    \
-          \      python3.11 -u run_main_ds.py --model_path /input_model/model --ckpt_output_dir\
+          \n\n    image = 'quay.io/shanand/test-train:0.0.4'\n    nprocPerNode = 3\n\
+          \    nnodes = 2\n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n \
+          \       apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n\
+          \          name: {name}\n        spec:\n          nprocPerNode: \\\\\"{nprocPerNode}\\\
+          \\\"\n          pytorchReplicaSpecs:\n            Master:\n            \
+          \  replicas: 1\n              restartPolicy: OnFailure\n              template:\n\
+          \                metadata:\n                  annotations:\n           \
+          \         sidecar.istio.io/inject: 'false'\n                spec:\n    \
+          \              containers:\n                    - args:\n              \
+          \          - |\n                          mkdir -p /output/model;\n    \
+          \                      mkdir -p /output/data;\n                        \
+          \  python3.11 -u run_main_ds.py --model_path /input_model/model --ckpt_output_dir\
           \ /output/model --data_output_dir /input_data/processed_data\n         \
           \             command:\n                        - /bin/bash\n          \
           \              - '-c'\n                        - '--'\n                \
@@ -805,10 +801,9 @@ deploymentSpec:
           \    replicas: {nnodes-1}\n              restartPolicy: OnFailure\n    \
           \          template:\n                metadata:\n                  annotations:\n\
           \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  nodeSelector:\n                    kubernetes.io/hostname:\
-          \ <NODE-NAME>\n                  containers:\n                    - args:\n\
-          \                        - |\n                          mkdir -p /tmp/model;\n\
-          \                          python3.11 -u run_main_ds.py --model_path /input_model/model\
+          \                  containers:\n                    - args:\n          \
+          \              - |\n                          mkdir -p /tmp/model;\n   \
+          \                       python3.11 -u run_main_ds.py --model_path /input_model/model\
           \ --ckpt_output_dir /tmp/model --data_output_dir /input_data/processed_data\n\
           \                      command:\n                        - /bin/bash\n \
           \                       - '-c'\n                        - '--'\n       \
@@ -843,7 +838,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -1026,7 +1021,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -1527,7 +1522,7 @@ root:
         isOptional: true
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.8.0
+sdkVersion: kfp-2.9.0
 ---
 platforms:
   kubernetes:

--- a/training/components.py
+++ b/training/components.py
@@ -83,11 +83,9 @@ def pytorchjob_manifest_op(
     name = f"train-{name_suffix.rstrip('-sdg')}"
 
     image = 'quay.io/shanand/test-train:0.0.4'
-    nprocPerNode = 1
+    nprocPerNode = 3
     nnodes = 2
-# (shanand): The master and the worker nodes have to be scheduled on a single OpenShift node for now. Once
-# the PVC issues are fixed this can be removed. Please 
-# update the nodeSelector <NODE-NAME> before compiling the pipeline or else it'll break.
+    
     manifest = inspect.cleandoc(
         f"""
         apiVersion: kubeflow.org/v1
@@ -105,8 +103,6 @@ def pytorchjob_manifest_op(
                   annotations:
                     sidecar.istio.io/inject: 'false'
                 spec:
-                  nodeSelector:
-                    kubernetes.io/hostname: <NODE-NAME>
                   containers:
                     - args:
                         - |
@@ -158,8 +154,6 @@ def pytorchjob_manifest_op(
                   annotations:
                     sidecar.istio.io/inject: 'false'
                 spec:
-                  nodeSelector:
-                    kubernetes.io/hostname: <NODE-NAME>
                   containers:
                     - args:
                         - |


### PR DESCRIPTION
This PR removed the "nodeSelector" spec from the pytorchJob and increased the number of GPU's per node to 3. Given our environment this will ensure that the training is always run across both nodes. In a **follow up PR** we will want to expose these training args to the user so that they can customize their training runs.   

This PR also updates the kfp 2.8.0 error introduced in #38 