### PR TITLE
set retry on artifact-to-pvc-op

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -111,6 +111,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             data=model_to_artifact.outputs["model"], pvc_path="/model"
         )
         model_to_pvc_task.set_caching_options(False)
+        model_to_pvc_task.set_retry(3)
         mount_pvc(
             task=model_to_pvc_task, pvc_name=model_pvc_task.output, mount_path="/model"
         )

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1235,6 +1235,11 @@ root:
             pvc_path:
               runtimeValue:
                 constant: /model
+        retryPolicy:
+          backoffDuration: 0s
+          backoffFactor: 2.0
+          backoffMaxDuration: 3600s
+          maxRetryCount: 3
         taskInfo:
           name: artifact-to-pvc-op
       artifact-to-pvc-op-2:


### PR DESCRIPTION
The `artifact-to-pvc-op` step can randomly fail due to network issues while moving the model from S3 to the PVC. This PR adds a `set_retry` to this step so that it will retry 3 times before failing the entire pipeline. 