### PR TITLE
add missing mandatory parameters for generate_data

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1221,7 +1221,8 @@ deploymentSpec:
           \ `empty`\n    # it allows generating from the whole repo, see:\n    # https://github.com/instructlab/sdg/blob/c6a9e74a1618b1077cd38e713b8aaed8b7c0c8ce/src/instructlab/sdg/utils/taxonomy.py#L230\n\
           \    generate_data(\n        client=client,\n        num_instructions_to_generate=num_instructions_to_generate,\n\
           \        output_dir=sdg.path,\n        taxonomy=taxonomy.path,\n       \
-          \ taxonomy_base=taxonomy_base,\n        model_name=model,\n    )\n\n"
+          \ taxonomy_base=taxonomy_base,\n        model_name=model,\n        chunk_word_count=1000,\n\
+          \        server_ctx_size=4096\n    )\n\n"
         image: quay.io/tcoufal/ilab-sdg:latest
 pipelineInfo:
   description: InstructLab pipeline

--- a/sdg/components.py
+++ b/sdg/components.py
@@ -60,4 +60,6 @@ def sdg_op(
         taxonomy=taxonomy.path,
         taxonomy_base=taxonomy_base,
         model_name=model,
+        chunk_word_count=1000,
+        server_ctx_size=4096,
     )


### PR DESCRIPTION
When running SDG with against taxonomy-base "empty", SDG failed due to missing mandatory parameters.

Users can trigger full SDG workflow by providing an arbitrary negative number as the pr number when initiating a pipeline run.