### PR TITLE
Remove MMLU step from phased training 

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -66,6 +66,8 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
     # Imports for MMLU, MT_BENCH stage
     # TODO: Add mock/fake components
     from eval.mmlu import load_mmlu_results_op, run_mmlu_op
+
+    ## from eval.mmlu import run_mmlu_op, load_mmlu_results_op
     from eval.mt_bench import load_mt_bench_results_op, run_mt_bench_op
     from utils import list_models_in_directory_op
 
@@ -82,7 +84,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
         storage_class_name: str = "nfs-csi",
         base_model: str = BASE_MODE,
         # minimal subset of MMLU_TASKS
-        mmlu_tasks_list: str = MMLU_TASKS_LIST,
+        # mmlu_tasks_list: str = MMLU_TASKS_LIST,
         model_dtype: str = MODEL_DTYPE,
         few_shots: int = FEW_SHOTS,
         batch_size: int = BATCH_SIZE,
@@ -165,7 +167,6 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             input_pvc_name=sdg_input_pvc_task.output,
             name_suffix=sdg_input_pvc_task.output,
             output_pvc_name=output_pvc_task.output,
-            path_to_model="/input_model/model",
             phase_name="first",
             nproc_per_node=nproc_per_node,
             nnodes=nnodes,
@@ -186,43 +187,48 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
         kubectl_wait_task.after(kubectl_apply_task)
         kubectl_wait_task.set_caching_options(False)
 
-        # MMLU Evaluation of models
+        # # MMLU Evaluation of models
 
-        models_list_task = list_models_in_directory_op(
-            models_folder="/output/model/model/hf_format",
-        )
-        models_list_task.set_caching_options(False)
+        # models_list_task = list_models_in_directory_op(
+        #     models_folder="/output/model/model/hf_format",
+        # )
+        # models_list_task.set_caching_options(False)
 
-        models_list_task.after(kubectl_wait_task)
+        # models_list_task.after(kubectl_wait_task)
 
-        mount_pvc(
-            task=models_list_task,
-            pvc_name=output_pvc_task.output,
-            mount_path="/output/model",
-        )
+        # mount_pvc(
+        #     task=models_list_task,
+        #     pvc_name=output_pvc_task.output,
+        #     mount_path="/output/model",
+        # )
 
-        run_mmlu_task = run_mmlu_op(
-            models_list=models_list_task.output,
-            models_path_prefix="/output/model/hf_format",
-            mmlu_tasks_list=mmlu_tasks_list,
-            model_dtype=model_dtype,
-            few_shots=few_shots,
-            batch_size=batch_size,
-            device=device,
-        )
+        # run_mmlu_task = run_mmlu_op(
+        #     models_list=models_list_task.output,
+        #     models_path_prefix="/output/model/hf_format",
+        #     mmlu_tasks_list=mmlu_tasks_list,
+        #     model_dtype=model_dtype,
+        #     few_shots=few_shots,
+        #     batch_size=batch_size,
+        #     device=device,
+        # )
 
-        run_mmlu_task.set_caching_options(False)
+        # run_mmlu_task.set_caching_options(False)
 
-        mount_pvc(
-            task=run_mmlu_task, pvc_name=output_pvc_task.output, mount_path="/output"
-        )
+        # mount_pvc(
+        #     task=run_mmlu_task, pvc_name=output_pvc_task.output, mount_path="/output"
+        # )
 
-        load_mmlu_results_task = load_mmlu_results_op(
-            mmlu_output=run_mmlu_task.outputs["mmlu_output"],
-        )
+        # load_mmlu_results_task = load_mmlu_results_op(
+        #     mmlu_output=run_mmlu_task.outputs["mmlu_output"],
+        # )
 
-        run_mmlu_task.set_accelerator_type("nvidia.com/gpu")
-        run_mmlu_task.set_accelerator_limit(1)
+        # run_mmlu_task.set_accelerator_type("nvidia.com/gpu")
+        # run_mmlu_task.set_accelerator_limit(1)
+
+        # #    Run training on MMLU best-model
+        # #    Run final eval on best scored mt_bench candidate
+        # #    For now, running mt_bench on same output models as training phase 1
+        # #    TODO: Another training phase, using the best-model from MMLU as base
 
         #### Train 2
 
@@ -231,13 +237,19 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             input_pvc_name=sdg_input_pvc_task.output,
             name_suffix=sdg_input_pvc_task.output,
             output_pvc_name=output_pvc_task.output,
-            path_to_model=run_mmlu_task.outputs["best_model"],
             phase_name="second",
             nproc_per_node=nproc_per_node,
             nnodes=nnodes,
         )
 
         pytorchjob_manifest_2_task.set_caching_options(False)
+        pytorchjob_manifest_2_task.after(kubectl_wait_task)
+
+        mount_pvc(
+            task=pytorchjob_manifest_2_task,
+            pvc_name=output_pvc_task.output,
+            mount_path="/output",
+        )
 
         kubectl_apply_2_task = kubectl_apply_op(
             manifest=pytorchjob_manifest_2_task.outputs["manifest"]

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -8,7 +8,6 @@
 #    few_shots: int [Default: 5.0]
 #    max_workers: str [Default: 'auto']
 #    merge_system_user_message: bool [Default: False]
-#    mmlu_tasks_list: str [Default: 'mmlu_anatomy,mmlu_astronomy']
 #    model_dtype: str [Default: 'bfloat16']
 #    nnodes: int [Default: 2.0]
 #    nproc_per_node: int [Default: 3.0]
@@ -344,28 +343,6 @@ components:
       parameters:
         Output:
           parameterType: LIST
-  comp-list-models-in-directory-op-2:
-    executorLabel: exec-list-models-in-directory-op-2
-    inputDefinitions:
-      parameters:
-        models_folder:
-          parameterType: STRING
-    outputDefinitions:
-      parameters:
-        Output:
-          parameterType: LIST
-  comp-load-mmlu-results-op:
-    executorLabel: exec-load-mmlu-results-op
-    inputDefinitions:
-      artifacts:
-        mmlu_output:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-    outputDefinitions:
-      parameters:
-        Output:
-          parameterType: LIST
   comp-pvc-to-artifact-op:
     executorLabel: exec-pvc-to-artifact-op
     inputDefinitions:
@@ -410,8 +387,6 @@ components:
           parameterType: NUMBER_INTEGER
         output_pvc_name:
           parameterType: STRING
-        path_to_model:
-          parameterType: STRING
         phase_name:
           parameterType: STRING
     outputDefinitions:
@@ -440,8 +415,6 @@ components:
           parameterType: NUMBER_INTEGER
         output_pvc_name:
           parameterType: STRING
-        path_to_model:
-          parameterType: STRING
         phase_name:
           parameterType: STRING
     outputDefinitions:
@@ -450,40 +423,6 @@ components:
           parameterType: STRING
         name:
           parameterType: STRING
-  comp-run-mmlu-op:
-    executorLabel: exec-run-mmlu-op
-    inputDefinitions:
-      parameters:
-        batch_size:
-          parameterType: NUMBER_INTEGER
-        device:
-          isOptional: true
-          parameterType: STRING
-        few_shots:
-          parameterType: NUMBER_INTEGER
-        mmlu_tasks_list:
-          parameterType: STRING
-        model_dtype:
-          parameterType: STRING
-        models_folder:
-          isOptional: true
-          parameterType: STRING
-        models_list:
-          isOptional: true
-          parameterType: LIST
-        models_path_prefix:
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        mmlu_output:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-      parameters:
-        best_model:
-          parameterType: STRING
-        best_score:
-          parameterType: NUMBER_DOUBLE
   comp-run-mt-bench-op:
     executorLabel: exec-run-mt-bench-op
     inputDefinitions:
@@ -742,68 +681,6 @@ deploymentSpec:
           \  import os\n\n    models = os.listdir(models_folder)\n    return models\n\
           \n"
         image: python:3.8
-    exec-list-models-in-directory-op-2:
-      container:
-        args:
-        - --executor_input
-        - '{{$}}'
-        - --function_to_execute
-        - list_models_in_directory_op
-        command:
-        - sh
-        - -c
-        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
-          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
-          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
-          $0\" \"$@\"\n"
-        - sh
-        - -ec
-        - 'program_path=$(mktemp -d)
-
-
-          printf "%s" "$0" > "$program_path/ephemeral_component.py"
-
-          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
-
-          '
-        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef list_models_in_directory_op(models_folder: str) -> List:\n  \
-          \  import os\n\n    models = os.listdir(models_folder)\n    return models\n\
-          \n"
-        image: python:3.8
-    exec-load-mmlu-results-op:
-      container:
-        args:
-        - --executor_input
-        - '{{$}}'
-        - --function_to_execute
-        - load_mmlu_results_op
-        command:
-        - sh
-        - -c
-        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
-          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
-          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
-          $0\" \"$@\"\n"
-        - sh
-        - -ec
-        - 'program_path=$(mktemp -d)
-
-
-          printf "%s" "$0" > "$program_path/ephemeral_component.py"
-
-          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
-
-          '
-        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef load_mmlu_results_op(mmlu_output: Input[Artifact]) -> list:\n\
-          \    import json\n\n    mmlu_score_list = []\n    with open(mmlu_output.path,\
-          \ \"r\") as f:\n        mmlu_score_list = json.load(f)\n\n    print(\"MMLU\
-          \ Evaluation Data:\")\n    for mmlu_score in mmlu_score_list:\n        print(json.dumps(mmlu_score,\
-          \ indent=4))\n\n    return mmlu_score_list\n\n"
-        image: registry.access.redhat.com/ubi9/python-311:latest
     exec-pvc-to-artifact-op:
       container:
         args:
@@ -847,22 +724,29 @@ deploymentSpec:
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef pytorchjob_manifest_op(\n    model_pvc_name: str,\n    input_pvc_name:\
-          \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n    path_to_model:\
+          \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n    # path_to_model:\
           \ str,\n    phase_name: str,\n    nproc_per_node: int = 3,\n    nnodes:\
           \ int = 2,\n) -> NamedTuple(\"outputs\", manifest=str, name=str):\n    import\
-          \ inspect\n\n    Outputs = NamedTuple(\"outputs\", manifest=str, name=str)\n\
-          \    name = f\"train-{phase_name}-{name_suffix.rstrip('-sdg')}\"\n\n   \
-          \ image = \"quay.io/shanand/test-train:0.0.4\"\n\n    manifest = inspect.cleandoc(\n\
-          \        f\"\"\"\n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n\
-          \        metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
-          \ \\\\\"{nproc_per_node}\\\\\"\n          pytorchReplicaSpecs:\n       \
-          \     Master:\n              replicas: 1\n              restartPolicy: OnFailure\n\
-          \              template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  containers:\n                    - args:\n          \
-          \              - |\n                          mkdir -p /output/model;\n\
-          \                          mkdir -p /output/data;\n                    \
-          \      python3.11 -u run_main_ds.py --model_path {path_to_model} --ckpt_output_dir\
+          \ inspect\n    import os\n\n    def list_phase1_final_model():\n       \
+          \ model_dir = \"/output/model/hf_format\"\n        models = os.listdir(model_dir)\n\
+          \        newest_idx = max(\n            (os.path.getmtime(model), i) for\
+          \ i, model in enumerate(models)\n        )[-1]\n        newest_model = models[newest_idx]\n\
+          \        return f\"{model_dir}/{newest_model}\"\n\n    Outputs = NamedTuple(\"\
+          outputs\", manifest=str, name=str)\n    name = f\"train-{phase_name}-{name_suffix.rstrip('-sdg')}\"\
+          \n\n    image = \"quay.io/shanand/test-train:0.0.4\"\n    if phase_name\
+          \ == \"first\":\n        path_to_model = \"/input_model/model\"\n    elif\
+          \ phase_name == \"second\":\n        path_to_model = list_phase1_final_model()\n\
+          \n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
+          \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
+          \   name: {name}\n        spec:\n          nprocPerNode: \\\\\"{nproc_per_node}\\\
+          \\\"\n          pytorchReplicaSpecs:\n            Master:\n            \
+          \  replicas: 1\n              restartPolicy: OnFailure\n              template:\n\
+          \                metadata:\n                  annotations:\n           \
+          \         sidecar.istio.io/inject: 'false'\n                spec:\n    \
+          \              containers:\n                    - args:\n              \
+          \          - |\n                          mkdir -p /output/model;\n    \
+          \                      mkdir -p /output/data;\n                        \
+          \  python3.11 -u run_main_ds.py --model_path {path_to_model} --ckpt_output_dir\
           \ /output/model --data_output_dir /input_data/processed_data\n         \
           \             command:\n                        - /bin/bash\n          \
           \              - '-c'\n                        - '--'\n                \
@@ -944,22 +828,29 @@ deploymentSpec:
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef pytorchjob_manifest_op(\n    model_pvc_name: str,\n    input_pvc_name:\
-          \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n    path_to_model:\
+          \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n    # path_to_model:\
           \ str,\n    phase_name: str,\n    nproc_per_node: int = 3,\n    nnodes:\
           \ int = 2,\n) -> NamedTuple(\"outputs\", manifest=str, name=str):\n    import\
-          \ inspect\n\n    Outputs = NamedTuple(\"outputs\", manifest=str, name=str)\n\
-          \    name = f\"train-{phase_name}-{name_suffix.rstrip('-sdg')}\"\n\n   \
-          \ image = \"quay.io/shanand/test-train:0.0.4\"\n\n    manifest = inspect.cleandoc(\n\
-          \        f\"\"\"\n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n\
-          \        metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
-          \ \\\\\"{nproc_per_node}\\\\\"\n          pytorchReplicaSpecs:\n       \
-          \     Master:\n              replicas: 1\n              restartPolicy: OnFailure\n\
-          \              template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  containers:\n                    - args:\n          \
-          \              - |\n                          mkdir -p /output/model;\n\
-          \                          mkdir -p /output/data;\n                    \
-          \      python3.11 -u run_main_ds.py --model_path {path_to_model} --ckpt_output_dir\
+          \ inspect\n    import os\n\n    def list_phase1_final_model():\n       \
+          \ model_dir = \"/output/model/hf_format\"\n        models = os.listdir(model_dir)\n\
+          \        newest_idx = max(\n            (os.path.getmtime(model), i) for\
+          \ i, model in enumerate(models)\n        )[-1]\n        newest_model = models[newest_idx]\n\
+          \        return f\"{model_dir}/{newest_model}\"\n\n    Outputs = NamedTuple(\"\
+          outputs\", manifest=str, name=str)\n    name = f\"train-{phase_name}-{name_suffix.rstrip('-sdg')}\"\
+          \n\n    image = \"quay.io/shanand/test-train:0.0.4\"\n    if phase_name\
+          \ == \"first\":\n        path_to_model = \"/input_model/model\"\n    elif\
+          \ phase_name == \"second\":\n        path_to_model = list_phase1_final_model()\n\
+          \n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
+          \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
+          \   name: {name}\n        spec:\n          nprocPerNode: \\\\\"{nproc_per_node}\\\
+          \\\"\n          pytorchReplicaSpecs:\n            Master:\n            \
+          \  replicas: 1\n              restartPolicy: OnFailure\n              template:\n\
+          \                metadata:\n                  annotations:\n           \
+          \         sidecar.istio.io/inject: 'false'\n                spec:\n    \
+          \              containers:\n                    - args:\n              \
+          \          - |\n                          mkdir -p /output/model;\n    \
+          \                      mkdir -p /output/data;\n                        \
+          \  python3.11 -u run_main_ds.py --model_path {path_to_model} --ckpt_output_dir\
           \ /output/model --data_output_dir /input_data/processed_data\n         \
           \             command:\n                        - /bin/bash\n          \
           \              - '-c'\n                        - '--'\n                \
@@ -1537,20 +1428,6 @@ root:
           name: comp-list-models-in-directory-op
         dependentTasks:
         - createpvc-3
-        - kubectl-wait-for-op
-        inputs:
-          parameters:
-            models_folder:
-              runtimeValue:
-                constant: /output/model/model/hf_format
-        taskInfo:
-          name: list-models-in-directory-op
-      list-models-in-directory-op-2:
-        cachingOptions: {}
-        componentRef:
-          name: comp-list-models-in-directory-op-2
-        dependentTasks:
-        - createpvc-3
         - kubectl-wait-for-op-2
         inputs:
           parameters:
@@ -1558,22 +1435,7 @@ root:
               runtimeValue:
                 constant: /output/model/model/hf_format
         taskInfo:
-          name: list-models-in-directory-op-2
-      load-mmlu-results-op:
-        cachingOptions:
-          enableCache: true
-        componentRef:
-          name: comp-load-mmlu-results-op
-        dependentTasks:
-        - run-mmlu-op
-        inputs:
-          artifacts:
-            mmlu_output:
-              taskOutputArtifact:
-                outputArtifactKey: mmlu_output
-                producerTask: run-mmlu-op
-        taskInfo:
-          name: load-mmlu-results-op
+          name: list-models-in-directory-op
       pvc-to-artifact-op:
         cachingOptions: {}
         componentRef:
@@ -1633,9 +1495,6 @@ root:
               taskOutputParameter:
                 outputParameterKey: name
                 producerTask: createpvc-3
-            path_to_model:
-              runtimeValue:
-                constant: /input_model/model
             phase_name:
               runtimeValue:
                 constant: first
@@ -1649,7 +1508,7 @@ root:
         - createpvc
         - createpvc-2
         - createpvc-3
-        - run-mmlu-op
+        - kubectl-wait-for-op
         inputs:
           parameters:
             input_pvc_name:
@@ -1672,50 +1531,18 @@ root:
               taskOutputParameter:
                 outputParameterKey: name
                 producerTask: createpvc-3
-            path_to_model:
-              taskOutputParameter:
-                outputParameterKey: best_model
-                producerTask: run-mmlu-op
             phase_name:
               runtimeValue:
                 constant: second
         taskInfo:
           name: pytorchjob-manifest-op-2
-      run-mmlu-op:
-        cachingOptions: {}
-        componentRef:
-          name: comp-run-mmlu-op
-        dependentTasks:
-        - createpvc-3
-        - list-models-in-directory-op
-        inputs:
-          parameters:
-            batch_size:
-              componentInputParameter: batch_size
-            device:
-              componentInputParameter: device
-            few_shots:
-              componentInputParameter: few_shots
-            mmlu_tasks_list:
-              componentInputParameter: mmlu_tasks_list
-            model_dtype:
-              componentInputParameter: model_dtype
-            models_list:
-              taskOutputParameter:
-                outputParameterKey: Output
-                producerTask: list-models-in-directory-op
-            models_path_prefix:
-              runtimeValue:
-                constant: /output/model/hf_format
-        taskInfo:
-          name: run-mmlu-op
       run-mt-bench-op:
         cachingOptions: {}
         componentRef:
           name: comp-run-mt-bench-op
         dependentTasks:
         - createpvc-3
-        - list-models-in-directory-op-2
+        - list-models-in-directory-op
         inputs:
           parameters:
             device:
@@ -1727,7 +1554,7 @@ root:
             models_list:
               taskOutputParameter:
                 outputParameterKey: Output
-                producerTask: list-models-in-directory-op-2
+                producerTask: list-models-in-directory-op
             models_path_prefix:
               runtimeValue:
                 constant: /output/model/hf_format
@@ -1780,10 +1607,6 @@ root:
         defaultValue: false
         isOptional: true
         parameterType: BOOLEAN
-      mmlu_tasks_list:
-        defaultValue: mmlu_anatomy,mmlu_astronomy
-        isOptional: true
-        parameterType: STRING
       model_dtype:
         defaultValue: bfloat16
         isOptional: true
@@ -1839,12 +1662,6 @@ platforms:
             taskOutputParameter:
               outputParameterKey: name
               producerTask: createpvc-3
-        exec-list-models-in-directory-op-2:
-          pvcMount:
-          - mountPath: /output/model
-            taskOutputParameter:
-              outputParameterKey: name
-              producerTask: createpvc-3
         exec-pvc-to-artifact-op:
           pvcMount:
           - mountPath: /output/data
@@ -1857,7 +1674,7 @@ platforms:
             taskOutputParameter:
               outputParameterKey: name
               producerTask: createpvc-3
-        exec-run-mmlu-op:
+        exec-pytorchjob-manifest-op-2:
           pvcMount:
           - mountPath: /output
             taskOutputParameter:

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -58,7 +58,7 @@ TRAINING_PVC_MOUNT_PATH = "/output"
 TRAINING_VOLUME_NAME = "output"
 PYTORCH_NNODES = 2
 PYTORCH_IMAGE = "quay.io/shanand/test-train:0.0.4"
-MMLU_SCORES_PATH = "/output/mmlu-results.txt"
+# MMLU_SCORES_PATH = "/output/mmlu-results.txt"
 MT_BENCH_SCORES_PATH = "/output/mt-bench-results.txt"
 SDG_OBJECT_STORE_SECRET_NAME = "sdg-object-store-credentials"
 KFP_MODEL_SERVER_CM = """
@@ -457,7 +457,7 @@ def show(
 @click.option(
     "--eval-type",
     help="Type of evaluation to run",
-    type=click.Choice(["mmlu", "mt-bench"]),
+    type=click.Choice(["mt-bench"]),
     hidden=True,
 )
 @click.option(
@@ -626,12 +626,12 @@ def run(
         ctx.invoke(train)
 
         # Evaluation of phase 1 with MMLU
-        ctx.obj["eval_type"] = "mmlu"
-        scores = ctx.invoke(evaluation)
-        scores = json.loads(scores)
-        best_model = max(scores, key=lambda x: x["average_score"])
-        logger.info("Best model: %s", best_model.get("model"))
-        ctx.obj["model_to_train"] = best_model.get("model")
+        # ctx.obj["eval_type"] = "mmlu"
+        # scores = ctx.invoke(evaluation)
+        # scores = json.loads(scores)
+        # best_model = max(scores, key=lambda x: x["average_score"])
+        # logger.info("Best model: %s", best_model.get("model"))
+        # ctx.obj["model_to_train"] = best_model.get("model")
 
         # Training Phase 2
         # ctx.invoke(train)
@@ -1013,7 +1013,32 @@ def create_eval_job(
         kubernetes.client.V1Job: A Kubernetes Job object configured with the specified parameters.
     """
 
-    if eval_type == "mmlu":
+    # if eval_type == "mmlu":
+    #     init_containers = [
+    #         kubernetes.client.V1Container(
+    #             name=f"run-eval-{eval_type}",
+    #             image="",
+    #             command=,
+    #             args=,
+    #             volume_mounts=[
+    #                 kubernetes.client.V1VolumeMount(
+    #                     name=TRAINING_VOLUME_NAME, mount_path=TRAINING_PVC_MOUNT_PATH
+    #                 ),
+    #             ],
+    #         )
+    #     ]
+    #     container = kubernetes.client.V1Container(
+    #         name=f"output-eval-{eval_type}-scores",
+    #         image="",
+    #         command=["/bin/sh", "-c"],
+    #         args=[f"cat {MMLU_SCORES_PATH}"],
+    #         volume_mounts=[
+    #             kubernetes.client.V1VolumeMount(
+    #                 name=TRAINING_VOLUME_NAME, mount_path=TRAINING_PVC_MOUNT_PATH
+    #             ),
+    #         ],
+    #     )
+    if eval_type == "mt-bench":
         init_containers = [
             kubernetes.client.V1Container(
                 name=f"run-eval-{eval_type}",
@@ -1651,9 +1676,7 @@ def evaluation(ctx: click.Context) -> str:
     eval_type = ctx.obj["eval_type"]
 
     if eval_type is None:
-        raise ValueError(
-            "Evaluation type must be provided with --eval-type=[mmlu|mt-bench]"
-        )
+        raise ValueError("Evaluation type must be provided with --eval-type=[mt-bench]")
 
     logger.info("Running %s evaluation.", eval_type)
 

--- a/training/components.py
+++ b/training/components.py
@@ -85,17 +85,31 @@ def pytorchjob_manifest_op(
     input_pvc_name: str,
     output_pvc_name: str,
     name_suffix: str,
-    path_to_model: str,
+    # path_to_model: str,
     phase_name: str,
     nproc_per_node: int = 3,
     nnodes: int = 2,
 ) -> NamedTuple("outputs", manifest=str, name=str):
     import inspect
+    import os
+
+    def list_phase1_final_model():
+        model_dir = "/output/model/hf_format"
+        models = os.listdir(model_dir)
+        newest_idx = max(
+            (os.path.getmtime(model), i) for i, model in enumerate(models)
+        )[-1]
+        newest_model = models[newest_idx]
+        return f"{model_dir}/{newest_model}"
 
     Outputs = NamedTuple("outputs", manifest=str, name=str)
     name = f"train-{phase_name}-{name_suffix.rstrip('-sdg')}"
 
     image = "quay.io/shanand/test-train:0.0.4"
+    if phase_name == "first":
+        path_to_model = "/input_model/model"
+    elif phase_name == "second":
+        path_to_model = list_phase1_final_model()
 
     manifest = inspect.cleandoc(
         f"""


### PR DESCRIPTION
Addresses #56 

This PR primarily comments out all the MMLU eval code to remove it from the pipeline. Once we confirm none of it is needed for the final eval pieces we can remove it in a follow up PR. 

This PR also adds a new function to `pytorchjob_manifest_op` that will promote the most recent model checkpoint from the first training phase as the starting model for the second training phase. 