### PR TITLE
Default to verify TLS when downloading data from S3

### DIFF
--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -275,7 +275,7 @@ def build_boto3_client():
     aws_secret_access_key=os.getenv('SDG_OBJECT_STORE_SECRET_KEY'),
     endpoint_url=os.getenv('SDG_OBJECT_STORE_ENDPOINT', None),
     region_name=os.getenv('SDG_OBJECT_STORE_REGION', None),
-    verify=str_to_bool(os.getenv('SDG_OBJECT_STORE_VERIFY_TLS', None))
+    verify=str_to_bool(os.getenv('SDG_OBJECT_STORE_VERIFY_TLS', 'true'))
 )
 
 def download_s3_file():
@@ -1952,7 +1952,9 @@ def sdg_data_fetch(
         if sdg_object_store_region:
             secret.string_data["region"] = sdg_object_store_region
 
-        if not sdg_object_store_verify_tls:
+        if sdg_object_store_verify_tls:
+            secret.string_data["verify_tls"] = "true"
+        else:
             secret.string_data["verify_tls"] = "false"
 
         try:

--- a/standalone/standalone.tpl
+++ b/standalone/standalone.tpl
@@ -260,7 +260,7 @@ def build_boto3_client():
     aws_secret_access_key=os.getenv('SDG_OBJECT_STORE_SECRET_KEY'),
     endpoint_url=os.getenv('SDG_OBJECT_STORE_ENDPOINT', None),
     region_name=os.getenv('SDG_OBJECT_STORE_REGION', None),
-    verify=str_to_bool(os.getenv('SDG_OBJECT_STORE_VERIFY_TLS', None))
+    verify=str_to_bool(os.getenv('SDG_OBJECT_STORE_VERIFY_TLS', 'true'))
 )
 
 def download_s3_file():
@@ -1574,7 +1574,9 @@ def sdg_data_fetch(
         if sdg_object_store_region:
             secret.string_data["region"] = sdg_object_store_region
 
-        if not sdg_object_store_verify_tls:
+        if sdg_object_store_verify_tls:
+            secret.string_data["verify_tls"] = "true"
+        else:
             secret.string_data["verify_tls"] = "false"
 
         try:


### PR DESCRIPTION
This also prevents from having thousands of `Unverified HTTPS request is being made to host s3.amazonaws.com` warning messages in the `fetch-sdg-files-from-object-store` container logs. 