### PR TITLE
fix: make sure all train workers are done

### DIFF
--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -2945,7 +2945,7 @@ def train(
                 )
 
                 master_pod_success = False
-                worker_pod_success = False
+                workers_pod_success = {}
                 # Always start by the last condition so that if the job is completed, we can stop
                 # watching If we don't do this, we might get 'stuck' into the Running condition and
                 # never stop
@@ -3011,8 +3011,13 @@ def train(
                                             "Pod '%s' completed successfully",
                                             pod_event.metadata.name,
                                         )
-                                        worker_pod_success = True
-                                    if master_pod_success and worker_pod_success:
+                                        # Add the worker pod to the list of successful pods
+                                        workers_pod_success[pod_event.metadata.name] = (
+                                            True
+                                        )
+                                    if master_pod_success and (
+                                        len(workers_pod_success) == worker_replicas
+                                    ):
                                         logger.info(
                                             "All PytorchJob Pods completed successfully"
                                         )

--- a/standalone/standalone.tpl
+++ b/standalone/standalone.tpl
@@ -2117,7 +2117,7 @@ def train(
                 )
 
                 master_pod_success = False
-                worker_pod_success = False
+                workers_pod_success = {}
                 # Always start by the last condition so that if the job is completed, we can stop
                 # watching If we don't do this, we might get 'stuck' into the Running condition and
                 # never stop
@@ -2183,8 +2183,13 @@ def train(
                                             "Pod '%s' completed successfully",
                                             pod_event.metadata.name,
                                         )
-                                        worker_pod_success = True
-                                    if master_pod_success and worker_pod_success:
+                                        # Add the worker pod to the list of successful pods
+                                        workers_pod_success[pod_event.metadata.name] = (
+                                            True
+                                        )
+                                    if master_pod_success and (
+                                        len(workers_pod_success) == worker_replicas
+                                    ):
                                         logger.info(
                                             "All PytorchJob Pods completed successfully"
                                         )


### PR DESCRIPTION
2f5ffae fix: make sure all train workers are done

commit 2f5ffae720be9bfd897e665f81582e421cc942c0
Author: Sébastien Han <seb@redhat.com>
Date:   Thu Oct 17 09:43:19 2024 +0200

    fix: make sure all train workers are done
    
    Previously, we were only counting a single train worker and assumed the
    whole training was done. Now we make sure all the worker are done before
    going to the next phase.
    
    Signed-off-by: Sébastien Han <seb@redhat.com>
