### PR TITLE
fixed incorrect data_processing_op_args

### DIFF
--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -1383,7 +1383,7 @@ def data_processing_op(
     data_processing(train_args=training_args)
 """
     exec_data_processing_op_args = f"""
-data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg={DATA_PVC_SDG_PATH}, model={DATA_PVC_SDG_PATH}, processed_data={PREPROCESSED_DATA_PATH})
+data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")
 """
 
     data_container = kubernetes.client.V1Container(

--- a/standalone/standalone.tpl
+++ b/standalone/standalone.tpl
@@ -1195,7 +1195,7 @@ def create_data_job(
 {{exec_data_processing_op_command}}
 """
     exec_data_processing_op_args = f"""
-data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg={DATA_PVC_SDG_PATH}, model={DATA_PVC_SDG_PATH}, processed_data={PREPROCESSED_DATA_PATH})
+data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", processed_data="{PREPROCESSED_DATA_PATH}")
 """
 
     data_container = kubernetes.client.V1Container(


### PR DESCRIPTION
This PR fixes a small error missed during review of #104. Needed to add quotation marks to the args in `exec_data_processing_op_args` and set model to `DATA_PVC_MODEL_PATH` instead of `DATA_PVC_SDG_PATH`