### PR TITLE
fix: improve pytorchjob in kfp

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -182,7 +182,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             input_pvc_name=sdg_input_pvc_task.output,
             name_suffix=sdg_input_pvc_task.output,
             output_pvc_name=output_pvc_task.output,
-            phase_name="first",
+            phase_num=1,
             nproc_per_node=nproc_per_node,
             nnodes=nnodes,
         )
@@ -252,7 +252,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             input_pvc_name=sdg_input_pvc_task.output,
             name_suffix=sdg_input_pvc_task.output,
             output_pvc_name=output_pvc_task.output,
-            phase_name="second",
+            phase_num=2,
             nproc_per_node=nproc_per_node,
             nnodes=nnodes,
         )

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -386,8 +386,20 @@ components:
     executorLabel: exec-pytorchjob-manifest-op
     inputDefinitions:
       parameters:
+        effective_batch_size:
+          defaultValue: 3840.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
         input_pvc_name:
           parameterType: STRING
+        learning_rate:
+          defaultValue: 0.0001
+          isOptional: true
+          parameterType: NUMBER_DOUBLE
+        max_batch_len:
+          defaultValue: 20000.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
         model_pvc_name:
           parameterType: STRING
         name_suffix:
@@ -400,10 +412,26 @@ components:
           defaultValue: 3.0
           isOptional: true
           parameterType: NUMBER_INTEGER
+        num_epochs:
+          defaultValue: 2.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
+        num_warmup_steps:
+          defaultValue: 800.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
         output_pvc_name:
           parameterType: STRING
-        phase_name:
-          parameterType: STRING
+        phase_num:
+          parameterType: NUMBER_INTEGER
+        save_samples:
+          defaultValue: 0.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
+        seed:
+          defaultValue: 42.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
     outputDefinitions:
       parameters:
         manifest:
@@ -414,8 +442,20 @@ components:
     executorLabel: exec-pytorchjob-manifest-op-2
     inputDefinitions:
       parameters:
+        effective_batch_size:
+          defaultValue: 3840.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
         input_pvc_name:
           parameterType: STRING
+        learning_rate:
+          defaultValue: 0.0001
+          isOptional: true
+          parameterType: NUMBER_DOUBLE
+        max_batch_len:
+          defaultValue: 20000.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
         model_pvc_name:
           parameterType: STRING
         name_suffix:
@@ -428,10 +468,26 @@ components:
           defaultValue: 3.0
           isOptional: true
           parameterType: NUMBER_INTEGER
+        num_epochs:
+          defaultValue: 2.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
+        num_warmup_steps:
+          defaultValue: 800.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
         output_pvc_name:
           parameterType: STRING
-        phase_name:
-          parameterType: STRING
+        phase_num:
+          parameterType: NUMBER_INTEGER
+        save_samples:
+          defaultValue: 0.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
+        seed:
+          defaultValue: 42.0
+          isOptional: true
+          parameterType: NUMBER_INTEGER
     outputDefinitions:
       parameters:
         manifest:
@@ -805,18 +861,23 @@ deploymentSpec:
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef pytorchjob_manifest_op(\n    model_pvc_name: str,\n    input_pvc_name:\
           \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n    # path_to_model:\
-          \ str,\n    phase_name: str,\n    nproc_per_node: int = 3,\n    nnodes:\
-          \ int = 2,\n) -> NamedTuple(\"outputs\", manifest=str, name=str):\n    import\
+          \ str,\n    phase_num: int,\n    nproc_per_node: int = 3,\n    nnodes: int\
+          \ = 2,\n    num_epochs: int = 2,\n    effective_batch_size: int = 3840,\n\
+          \    learning_rate: float = 1e-4,\n    num_warmup_steps: int = 800,\n  \
+          \  save_samples: int = 0,\n    max_batch_len: int = 20000,\n    seed: int\
+          \ = 42,\n) -> NamedTuple(\"outputs\", manifest=str, name=str):\n    import\
           \ inspect\n    import os\n\n    def list_phase1_final_model():\n       \
           \ model_dir = \"/output/model/hf_format\"\n        models = os.listdir(model_dir)\n\
           \        newest_idx = max(\n            (os.path.getmtime(f\"{model_dir}/{model}\"\
           ), i)\n            for i, model in enumerate(models)\n        )[-1]\n  \
           \      newest_model = models[newest_idx]\n        return f\"{model_dir}/{newest_model}\"\
           \n\n    Outputs = NamedTuple(\"outputs\", manifest=str, name=str)\n    name\
-          \ = f\"train-{phase_name}-{name_suffix.rstrip('-sdg')}\"\n    if phase_name\
-          \ == \"first\":\n        path_to_model = \"/input_model/model\"\n    elif\
-          \ phase_name == \"second\":\n        path_to_model = list_phase1_final_model()\n\
-          \    image = \"registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2\"\
+          \ = f\"train-phase-{phase_num}-{name_suffix.rstrip('-sdg')}\"\n\n    if\
+          \ phase_num == 1:\n        path_to_model = \"/input_model/model\"\n    \
+          \    path_to_data = \"/input_data/knowledge_processed_data/data.jsonl\"\n\
+          \    elif phase_num == 2:\n        path_to_model = list_phase1_final_model()\n\
+          \        path_to_data = \"/input_data/skills_processed_data/data.jsonl\"\
+          \n\n    image = \"registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2\"\
           \n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
           \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
           \   name: {name}\n        spec:\n          nprocPerNode: \\\\\"{nproc_per_node}\\\
@@ -825,77 +886,109 @@ deploymentSpec:
           \                metadata:\n                  annotations:\n           \
           \         sidecar.istio.io/inject: 'false'\n                spec:\n    \
           \              containers:\n                    - args:\n              \
-          \          - |\n                          mkdir -p /output/model;\n    \
-          \                      mkdir -p /output/data;\n                        \
-          \  export XDG_CACHE_HOME=/tmp\n                          export TRITON_CACHE_DIR=/tmp\n\
-          \                          export HF_HOME=/tmp\n                       \
-          \   export TRANSFORMERS_CACHE=/tmp\n                          torchrun --nnodes\
-          \ {nnodes} --nproc_per_node {nproc_per_node} --node_rank \\$(RANK) --rdzv_endpoint\
-          \ \\$(MASTER_ADDR):\\$(MASTER_PORT) -m instructlab.training.main_ds --model_name_or_path={path_to_model}\
-          \ --data_path=/input_data/processed_data/data.jsonl --output_dir=/output/model\
-          \ --num_epochs=2 --effective_batch_size=3840 --learning_rate=1e-4 --num_warmup_steps=800\
-          \ --save_samples=0 --log_level=INFO --max_batch_len=20000 --seed=42 --cpu_offload_optimizer\
-          \ --distributed_training_framework fsdp --is_granite --checkpoint_at_epoch\n\
-          \                      command:\n                        - /bin/bash\n \
-          \                       - '-c'\n                        - '--'\n       \
-          \               image: {image}\n                      name: pytorch\n  \
-          \                    volumeMounts:\n                        - mountPath:\
-          \ /input_data\n                          name: input-data\n            \
-          \              readOnly: true\n                        - mountPath: /input_model\n\
-          \                          name: model\n                          readOnly:\
-          \ true\n                        - mountPath: /output\n                 \
-          \         name: output\n                      env:\n                   \
-          \     - name: NNODES\n                          value: \\\\\"{nnodes}\\\\\
-          \"\n                        - name: NPROC_PER_NODE\n                   \
-          \       value: \\\\\"{nproc_per_node}\\\\\"\n                      resources:\n\
-          \                        requests:\n                          cpu: 2\n \
+          \          - |\n                          echo \"Running phase {phase_num}\"\
+          \n                          echo \"Using {path_to_model} model for training\"\
+          \n                          echo \"Using {path_to_data} data for training\"\
+          \n                          mkdir -p /output/model;\n                  \
+          \        mkdir -p /output/data;\n                          torchrun --nnodes\
+          \ {nnodes} \\\n                              --nproc_per_node {nproc_per_node}\
+          \ \\\n                              --node_rank \\$(RANK) \\\n         \
+          \                     --rdzv_endpoint \\$(MASTER_ADDR):\\$(MASTER_PORT)\
+          \ \\\n                              -m instructlab.training.main_ds \\\n\
+          \                              --model_name_or_path={path_to_model} \\\n\
+          \                              --data_path={path_to_data} \\\n         \
+          \                     --output_dir=/output/model \\\n                  \
+          \            --num_epochs={num_epochs} \\\n                            \
+          \  --effective_batch_size={effective_batch_size} \\\n                  \
+          \            --learning_rate={learning_rate} \\\n                      \
+          \        --num_warmup_steps={num_warmup_steps} \\\n                    \
+          \          --save_samples={save_samples} \\\n                          \
+          \    --log_level=INFO \\\n                              --max_batch_len={max_batch_len}\
+          \ \\\n                              --seed={seed} \\\n                 \
+          \             --cpu_offload_optimizer \\\n                             \
+          \ --cpu_offload_params \\\n                              --distributed_training_framework\
+          \ fsdp \\\n                              --is_granite \\\n             \
+          \                 --checkpoint_at_epoch\n                      command:\n\
+          \                        - /bin/bash\n                        - '-c'\n \
+          \                       - '--'\n                      image: {image}\n \
+          \                     name: pytorch\n                      volumeMounts:\n\
+          \                        - mountPath: /input_data\n                    \
+          \      name: input-data\n                          readOnly: true\n    \
+          \                    - mountPath: /input_model\n                       \
+          \   name: model\n                          readOnly: true\n            \
+          \            - mountPath: /output\n                          name: output\n\
+          \                      env:\n                        - name: NNODES\n  \
+          \                        value: \\\\\"{nnodes}\\\\\"\n                 \
+          \       - name: NPROC_PER_NODE\n                          value: \\\\\"\
+          {nproc_per_node}\\\\\"\n                        - name: XDG_CACHE_HOME\n\
+          \                          value: /tmp\n                        - name:\
+          \ TRITON_CACHE_DIR\n                          value: /tmp\n            \
+          \            - name: HF_HOME\n                          value: /tmp\n  \
+          \                      - name: TRANSFORMERS_CACHE\n                    \
+          \      value: /tmp\n                      resources:\n                 \
+          \       requests:\n                          cpu: 8\n                  \
+          \        \"nvidia.com/gpu\": {nproc_per_node}\n                        limits:\n\
+          \                          cpu: 8\n                          \"nvidia.com/gpu\"\
+          : {nproc_per_node}\n                  volumes:\n                    - name:\
+          \ input-data\n                      persistentVolumeClaim:\n           \
+          \             claimName: {input_pvc_name}\n                    - name: model\n\
+          \                      persistentVolumeClaim:\n                        claimName:\
+          \ {model_pvc_name}\n                    - name: output\n               \
+          \       persistentVolumeClaim:\n                        claimName: {output_pvc_name}\n\
+          \            Worker:\n              replicas: {nnodes-1}\n             \
+          \ restartPolicy: OnFailure\n              template:\n                metadata:\n\
+          \                  annotations:\n                    sidecar.istio.io/inject:\
+          \ 'false'\n                spec:\n                  containers:\n      \
+          \              - args:\n                        - |\n                  \
+          \        echo \"Running phase {phase_num}\"\n                          echo\
+          \ \"Using {path_to_model} model for training\"\n                       \
+          \   echo \"Using {path_to_data} data for training\"\n                  \
+          \        mkdir -p /tmp/model;\n                          torchrun --nnodes\
+          \ {nnodes} \\\n                            --nproc_per_node {nproc_per_node}\
+          \ \\\n                            --node_rank \\$(RANK) \\\n           \
+          \                 --rdzv_endpoint \\$(MASTER_ADDR):\\$(MASTER_PORT) \\\n\
+          \                            -m instructlab.training.main_ds \\\n      \
+          \                      --model_name_or_path={path_to_model} \\\n       \
+          \                     --data_path={path_to_data} \\\n                  \
+          \          --output_dir=/tmp/model \\\n                            --num_epochs={num_epochs}\
+          \ \\\n                            --effective_batch_size={effective_batch_size}\
+          \ \\\n                            --learning_rate={learning_rate} \\\n \
+          \                           --num_warmup_steps={num_warmup_steps} \\\n \
+          \                           --save_samples={save_samples} \\\n         \
+          \                   --log_level=INFO \\\n                            --max_batch_len={max_batch_len}\
+          \ \\\n                            --seed={seed} \\\n                   \
+          \         --cpu_offload_optimizer \\\n                            --cpu_offload_params\
+          \ \\\n                            --distributed_training_framework fsdp\
+          \ \\\n                            --is_granite \\\n                    \
+          \        --checkpoint_at_epoch\n                      command:\n       \
+          \                 - /bin/bash\n                        - '-c'\n        \
+          \                - '--'\n                      image: {image}\n        \
+          \              name: pytorch\n                      volumeMounts:\n    \
+          \                    - mountPath: /input_data\n                        \
+          \  name: input-data\n                          readOnly: true\n        \
+          \                - mountPath: /input_model\n                          name:\
+          \ model\n                          readOnly: true\n                    \
+          \    - mountPath: /output\n                          name: output\n    \
+          \                      readOnly: true\n                      env:\n    \
+          \                    - name: NNODES\n                          value: \\\
+          \\\"{nnodes}\\\\\"\n                        - name: NPROC_PER_NODE\n   \
+          \                       value: \\\\\"{nproc_per_node}\\\\\"\n          \
+          \              - name: XDG_CACHE_HOME\n                          value:\
+          \ /tmp\n                        - name: TRITON_CACHE_DIR\n             \
+          \             value: /tmp\n                        - name: HF_HOME\n   \
+          \                       value: /tmp\n                        - name: TRANSFORMERS_CACHE\n\
+          \                          value: /tmp\n                      resources:\n\
+          \                        requests:\n                          cpu: 8\n \
           \                         \"nvidia.com/gpu\": {nproc_per_node}\n       \
-          \                 limits:\n                          cpu: 2\n          \
+          \                 limits:\n                          cpu: 8\n          \
           \                \"nvidia.com/gpu\": {nproc_per_node}\n                \
           \  volumes:\n                    - name: input-data\n                  \
           \    persistentVolumeClaim:\n                        claimName: {input_pvc_name}\n\
           \                    - name: model\n                      persistentVolumeClaim:\n\
           \                        claimName: {model_pvc_name}\n                 \
           \   - name: output\n                      persistentVolumeClaim:\n     \
-          \                   claimName: {output_pvc_name}\n            Worker:\n\
-          \              replicas: {nnodes-1}\n              restartPolicy: OnFailure\n\
-          \              template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  containers:\n                    - args:\n          \
-          \              - |\n                          mkdir -p /tmp/model;\n   \
-          \                       export TRITON_CACHE_DIR=/tmp\n                 \
-          \         export XDG_CACHE_HOME=/tmp\n                          export HF_HOME=/tmp\n\
-          \                          export TRANSFORMERS_CACHE=/tmp\n            \
-          \              torchrun --nnodes {nnodes} --nproc_per_node {nproc_per_node}\
-          \ --node_rank \\$(RANK) --rdzv_endpoint \\$(MASTER_ADDR):\\$(MASTER_PORT)\
-          \ -m instructlab.training.main_ds --model_name_or_path={path_to_model} \
-          \ --data_path=/input_data/processed_data/data.jsonl --output_dir=/tmp/model\
-          \ --num_epochs=2 --effective_batch_size=3840 --learning_rate=1e-4 --num_warmup_steps=800\
-          \ --save_samples=0 --log_level=INFO --max_batch_len=20000 --seed=42 --cpu_offload_optimizer\
-          \ --distributed_training_framework fsdp --is_granite --checkpoint_at_epoch\n\
-          \                      command:\n                        - /bin/bash\n \
-          \                       - '-c'\n                        - '--'\n       \
-          \               image: {image}\n                      name: pytorch\n  \
-          \                    volumeMounts:\n                        - mountPath:\
-          \ /input_data\n                          name: input-data\n            \
-          \              readOnly: true\n                        - mountPath: /input_model\n\
-          \                          name: model\n                          readOnly:\
-          \ true\n                        - mountPath: /output\n                 \
-          \         name: output\n                          readOnly: true\n     \
-          \                 env:\n                        - name: NNODES\n       \
-          \                   value: \\\\\"{nnodes}\\\\\"\n                      \
-          \  - name: NPROC_PER_NODE\n                          value: \\\\\"{nproc_per_node}\\\
-          \\\"\n                      resources:\n                        requests:\n\
-          \                          cpu: 2\n                          \"nvidia.com/gpu\"\
-          : {nproc_per_node}\n                        limits:\n                  \
-          \        cpu: 2\n                          \"nvidia.com/gpu\": {nproc_per_node}\n\
-          \                  volumes:\n                    - name: input-data\n  \
-          \                    persistentVolumeClaim:\n                        claimName:\
-          \ {input_pvc_name}\n                    - name: model\n                \
-          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
-          \                    - name: output\n                      persistentVolumeClaim:\n\
-          \                        claimName: {output_pvc_name}\n        \"\"\"\n\
-          \    )\n\n    return Outputs(manifest, name)\n\n"
+          \                   claimName: {output_pvc_name}\n        \"\"\"\n    )\n\
+          \n    return Outputs(manifest, name)\n\n"
         image: registry.access.redhat.com/ubi9/python-311:latest
     exec-pytorchjob-manifest-op-2:
       container:
@@ -925,18 +1018,23 @@ deploymentSpec:
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef pytorchjob_manifest_op(\n    model_pvc_name: str,\n    input_pvc_name:\
           \ str,\n    output_pvc_name: str,\n    name_suffix: str,\n    # path_to_model:\
-          \ str,\n    phase_name: str,\n    nproc_per_node: int = 3,\n    nnodes:\
-          \ int = 2,\n) -> NamedTuple(\"outputs\", manifest=str, name=str):\n    import\
+          \ str,\n    phase_num: int,\n    nproc_per_node: int = 3,\n    nnodes: int\
+          \ = 2,\n    num_epochs: int = 2,\n    effective_batch_size: int = 3840,\n\
+          \    learning_rate: float = 1e-4,\n    num_warmup_steps: int = 800,\n  \
+          \  save_samples: int = 0,\n    max_batch_len: int = 20000,\n    seed: int\
+          \ = 42,\n) -> NamedTuple(\"outputs\", manifest=str, name=str):\n    import\
           \ inspect\n    import os\n\n    def list_phase1_final_model():\n       \
           \ model_dir = \"/output/model/hf_format\"\n        models = os.listdir(model_dir)\n\
           \        newest_idx = max(\n            (os.path.getmtime(f\"{model_dir}/{model}\"\
           ), i)\n            for i, model in enumerate(models)\n        )[-1]\n  \
           \      newest_model = models[newest_idx]\n        return f\"{model_dir}/{newest_model}\"\
           \n\n    Outputs = NamedTuple(\"outputs\", manifest=str, name=str)\n    name\
-          \ = f\"train-{phase_name}-{name_suffix.rstrip('-sdg')}\"\n    if phase_name\
-          \ == \"first\":\n        path_to_model = \"/input_model/model\"\n    elif\
-          \ phase_name == \"second\":\n        path_to_model = list_phase1_final_model()\n\
-          \    image = \"registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2\"\
+          \ = f\"train-phase-{phase_num}-{name_suffix.rstrip('-sdg')}\"\n\n    if\
+          \ phase_num == 1:\n        path_to_model = \"/input_model/model\"\n    \
+          \    path_to_data = \"/input_data/knowledge_processed_data/data.jsonl\"\n\
+          \    elif phase_num == 2:\n        path_to_model = list_phase1_final_model()\n\
+          \        path_to_data = \"/input_data/skills_processed_data/data.jsonl\"\
+          \n\n    image = \"registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2\"\
           \n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
           \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
           \   name: {name}\n        spec:\n          nprocPerNode: \\\\\"{nproc_per_node}\\\
@@ -945,77 +1043,109 @@ deploymentSpec:
           \                metadata:\n                  annotations:\n           \
           \         sidecar.istio.io/inject: 'false'\n                spec:\n    \
           \              containers:\n                    - args:\n              \
-          \          - |\n                          mkdir -p /output/model;\n    \
-          \                      mkdir -p /output/data;\n                        \
-          \  export XDG_CACHE_HOME=/tmp\n                          export TRITON_CACHE_DIR=/tmp\n\
-          \                          export HF_HOME=/tmp\n                       \
-          \   export TRANSFORMERS_CACHE=/tmp\n                          torchrun --nnodes\
-          \ {nnodes} --nproc_per_node {nproc_per_node} --node_rank \\$(RANK) --rdzv_endpoint\
-          \ \\$(MASTER_ADDR):\\$(MASTER_PORT) -m instructlab.training.main_ds --model_name_or_path={path_to_model}\
-          \ --data_path=/input_data/processed_data/data.jsonl --output_dir=/output/model\
-          \ --num_epochs=2 --effective_batch_size=3840 --learning_rate=1e-4 --num_warmup_steps=800\
-          \ --save_samples=0 --log_level=INFO --max_batch_len=20000 --seed=42 --cpu_offload_optimizer\
-          \ --distributed_training_framework fsdp --is_granite --checkpoint_at_epoch\n\
-          \                      command:\n                        - /bin/bash\n \
-          \                       - '-c'\n                        - '--'\n       \
-          \               image: {image}\n                      name: pytorch\n  \
-          \                    volumeMounts:\n                        - mountPath:\
-          \ /input_data\n                          name: input-data\n            \
-          \              readOnly: true\n                        - mountPath: /input_model\n\
-          \                          name: model\n                          readOnly:\
-          \ true\n                        - mountPath: /output\n                 \
-          \         name: output\n                      env:\n                   \
-          \     - name: NNODES\n                          value: \\\\\"{nnodes}\\\\\
-          \"\n                        - name: NPROC_PER_NODE\n                   \
-          \       value: \\\\\"{nproc_per_node}\\\\\"\n                      resources:\n\
-          \                        requests:\n                          cpu: 2\n \
+          \          - |\n                          echo \"Running phase {phase_num}\"\
+          \n                          echo \"Using {path_to_model} model for training\"\
+          \n                          echo \"Using {path_to_data} data for training\"\
+          \n                          mkdir -p /output/model;\n                  \
+          \        mkdir -p /output/data;\n                          torchrun --nnodes\
+          \ {nnodes} \\\n                              --nproc_per_node {nproc_per_node}\
+          \ \\\n                              --node_rank \\$(RANK) \\\n         \
+          \                     --rdzv_endpoint \\$(MASTER_ADDR):\\$(MASTER_PORT)\
+          \ \\\n                              -m instructlab.training.main_ds \\\n\
+          \                              --model_name_or_path={path_to_model} \\\n\
+          \                              --data_path={path_to_data} \\\n         \
+          \                     --output_dir=/output/model \\\n                  \
+          \            --num_epochs={num_epochs} \\\n                            \
+          \  --effective_batch_size={effective_batch_size} \\\n                  \
+          \            --learning_rate={learning_rate} \\\n                      \
+          \        --num_warmup_steps={num_warmup_steps} \\\n                    \
+          \          --save_samples={save_samples} \\\n                          \
+          \    --log_level=INFO \\\n                              --max_batch_len={max_batch_len}\
+          \ \\\n                              --seed={seed} \\\n                 \
+          \             --cpu_offload_optimizer \\\n                             \
+          \ --cpu_offload_params \\\n                              --distributed_training_framework\
+          \ fsdp \\\n                              --is_granite \\\n             \
+          \                 --checkpoint_at_epoch\n                      command:\n\
+          \                        - /bin/bash\n                        - '-c'\n \
+          \                       - '--'\n                      image: {image}\n \
+          \                     name: pytorch\n                      volumeMounts:\n\
+          \                        - mountPath: /input_data\n                    \
+          \      name: input-data\n                          readOnly: true\n    \
+          \                    - mountPath: /input_model\n                       \
+          \   name: model\n                          readOnly: true\n            \
+          \            - mountPath: /output\n                          name: output\n\
+          \                      env:\n                        - name: NNODES\n  \
+          \                        value: \\\\\"{nnodes}\\\\\"\n                 \
+          \       - name: NPROC_PER_NODE\n                          value: \\\\\"\
+          {nproc_per_node}\\\\\"\n                        - name: XDG_CACHE_HOME\n\
+          \                          value: /tmp\n                        - name:\
+          \ TRITON_CACHE_DIR\n                          value: /tmp\n            \
+          \            - name: HF_HOME\n                          value: /tmp\n  \
+          \                      - name: TRANSFORMERS_CACHE\n                    \
+          \      value: /tmp\n                      resources:\n                 \
+          \       requests:\n                          cpu: 8\n                  \
+          \        \"nvidia.com/gpu\": {nproc_per_node}\n                        limits:\n\
+          \                          cpu: 8\n                          \"nvidia.com/gpu\"\
+          : {nproc_per_node}\n                  volumes:\n                    - name:\
+          \ input-data\n                      persistentVolumeClaim:\n           \
+          \             claimName: {input_pvc_name}\n                    - name: model\n\
+          \                      persistentVolumeClaim:\n                        claimName:\
+          \ {model_pvc_name}\n                    - name: output\n               \
+          \       persistentVolumeClaim:\n                        claimName: {output_pvc_name}\n\
+          \            Worker:\n              replicas: {nnodes-1}\n             \
+          \ restartPolicy: OnFailure\n              template:\n                metadata:\n\
+          \                  annotations:\n                    sidecar.istio.io/inject:\
+          \ 'false'\n                spec:\n                  containers:\n      \
+          \              - args:\n                        - |\n                  \
+          \        echo \"Running phase {phase_num}\"\n                          echo\
+          \ \"Using {path_to_model} model for training\"\n                       \
+          \   echo \"Using {path_to_data} data for training\"\n                  \
+          \        mkdir -p /tmp/model;\n                          torchrun --nnodes\
+          \ {nnodes} \\\n                            --nproc_per_node {nproc_per_node}\
+          \ \\\n                            --node_rank \\$(RANK) \\\n           \
+          \                 --rdzv_endpoint \\$(MASTER_ADDR):\\$(MASTER_PORT) \\\n\
+          \                            -m instructlab.training.main_ds \\\n      \
+          \                      --model_name_or_path={path_to_model} \\\n       \
+          \                     --data_path={path_to_data} \\\n                  \
+          \          --output_dir=/tmp/model \\\n                            --num_epochs={num_epochs}\
+          \ \\\n                            --effective_batch_size={effective_batch_size}\
+          \ \\\n                            --learning_rate={learning_rate} \\\n \
+          \                           --num_warmup_steps={num_warmup_steps} \\\n \
+          \                           --save_samples={save_samples} \\\n         \
+          \                   --log_level=INFO \\\n                            --max_batch_len={max_batch_len}\
+          \ \\\n                            --seed={seed} \\\n                   \
+          \         --cpu_offload_optimizer \\\n                            --cpu_offload_params\
+          \ \\\n                            --distributed_training_framework fsdp\
+          \ \\\n                            --is_granite \\\n                    \
+          \        --checkpoint_at_epoch\n                      command:\n       \
+          \                 - /bin/bash\n                        - '-c'\n        \
+          \                - '--'\n                      image: {image}\n        \
+          \              name: pytorch\n                      volumeMounts:\n    \
+          \                    - mountPath: /input_data\n                        \
+          \  name: input-data\n                          readOnly: true\n        \
+          \                - mountPath: /input_model\n                          name:\
+          \ model\n                          readOnly: true\n                    \
+          \    - mountPath: /output\n                          name: output\n    \
+          \                      readOnly: true\n                      env:\n    \
+          \                    - name: NNODES\n                          value: \\\
+          \\\"{nnodes}\\\\\"\n                        - name: NPROC_PER_NODE\n   \
+          \                       value: \\\\\"{nproc_per_node}\\\\\"\n          \
+          \              - name: XDG_CACHE_HOME\n                          value:\
+          \ /tmp\n                        - name: TRITON_CACHE_DIR\n             \
+          \             value: /tmp\n                        - name: HF_HOME\n   \
+          \                       value: /tmp\n                        - name: TRANSFORMERS_CACHE\n\
+          \                          value: /tmp\n                      resources:\n\
+          \                        requests:\n                          cpu: 8\n \
           \                         \"nvidia.com/gpu\": {nproc_per_node}\n       \
-          \                 limits:\n                          cpu: 2\n          \
+          \                 limits:\n                          cpu: 8\n          \
           \                \"nvidia.com/gpu\": {nproc_per_node}\n                \
           \  volumes:\n                    - name: input-data\n                  \
           \    persistentVolumeClaim:\n                        claimName: {input_pvc_name}\n\
           \                    - name: model\n                      persistentVolumeClaim:\n\
           \                        claimName: {model_pvc_name}\n                 \
           \   - name: output\n                      persistentVolumeClaim:\n     \
-          \                   claimName: {output_pvc_name}\n            Worker:\n\
-          \              replicas: {nnodes-1}\n              restartPolicy: OnFailure\n\
-          \              template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  containers:\n                    - args:\n          \
-          \              - |\n                          mkdir -p /tmp/model;\n   \
-          \                       export TRITON_CACHE_DIR=/tmp\n                 \
-          \         export XDG_CACHE_HOME=/tmp\n                          export HF_HOME=/tmp\n\
-          \                          export TRANSFORMERS_CACHE=/tmp\n            \
-          \              torchrun --nnodes {nnodes} --nproc_per_node {nproc_per_node}\
-          \ --node_rank \\$(RANK) --rdzv_endpoint \\$(MASTER_ADDR):\\$(MASTER_PORT)\
-          \ -m instructlab.training.main_ds --model_name_or_path={path_to_model} \
-          \ --data_path=/input_data/processed_data/data.jsonl --output_dir=/tmp/model\
-          \ --num_epochs=2 --effective_batch_size=3840 --learning_rate=1e-4 --num_warmup_steps=800\
-          \ --save_samples=0 --log_level=INFO --max_batch_len=20000 --seed=42 --cpu_offload_optimizer\
-          \ --distributed_training_framework fsdp --is_granite --checkpoint_at_epoch\n\
-          \                      command:\n                        - /bin/bash\n \
-          \                       - '-c'\n                        - '--'\n       \
-          \               image: {image}\n                      name: pytorch\n  \
-          \                    volumeMounts:\n                        - mountPath:\
-          \ /input_data\n                          name: input-data\n            \
-          \              readOnly: true\n                        - mountPath: /input_model\n\
-          \                          name: model\n                          readOnly:\
-          \ true\n                        - mountPath: /output\n                 \
-          \         name: output\n                          readOnly: true\n     \
-          \                 env:\n                        - name: NNODES\n       \
-          \                   value: \\\\\"{nnodes}\\\\\"\n                      \
-          \  - name: NPROC_PER_NODE\n                          value: \\\\\"{nproc_per_node}\\\
-          \\\"\n                      resources:\n                        requests:\n\
-          \                          cpu: 2\n                          \"nvidia.com/gpu\"\
-          : {nproc_per_node}\n                        limits:\n                  \
-          \        cpu: 2\n                          \"nvidia.com/gpu\": {nproc_per_node}\n\
-          \                  volumes:\n                    - name: input-data\n  \
-          \                    persistentVolumeClaim:\n                        claimName:\
-          \ {input_pvc_name}\n                    - name: model\n                \
-          \      persistentVolumeClaim:\n                        claimName: {model_pvc_name}\n\
-          \                    - name: output\n                      persistentVolumeClaim:\n\
-          \                        claimName: {output_pvc_name}\n        \"\"\"\n\
-          \    )\n\n    return Outputs(manifest, name)\n\n"
+          \                   claimName: {output_pvc_name}\n        \"\"\"\n    )\n\
+          \n    return Outputs(manifest, name)\n\n"
         image: registry.access.redhat.com/ubi9/python-311:latest
     exec-run-final-eval-op:
       container:
@@ -1821,9 +1951,9 @@ root:
               taskOutputParameter:
                 outputParameterKey: name
                 producerTask: createpvc-3
-            phase_name:
+            phase_num:
               runtimeValue:
-                constant: first
+                constant: 1.0
         taskInfo:
           name: pytorchjob-manifest-op
       pytorchjob-manifest-op-2:
@@ -1857,9 +1987,9 @@ root:
               taskOutputParameter:
                 outputParameterKey: name
                 producerTask: createpvc-3
-            phase_name:
+            phase_num:
               runtimeValue:
-                constant: second
+                constant: 2.0
         taskInfo:
           name: pytorchjob-manifest-op-2
       run-final-eval-op:


### PR DESCRIPTION
This PR includes a number of changes to improve the pytorchjob in `training/components.py`

* Changed `phase_name` parameter to `phase_num` to align with the pytorchjob in the standalone script.
* Made all numerical parameters in the `torchrun` call configurable through the  `pytorchjob_manifest_op()` args.
* Enforced phase 1 training to be on `knowledge_processed_data/data.json` and phase 2 training to be on `skills_processed_data/data.jsonl`.
* Moved `EXPORT` calls out of the container args and put them in the correct `env:` section of the container spec. 
* Reformatted the `torchrun` args for better readability.
* Added a couple echo statements to make sure users can easily see what model and dataset are being used in each training  pod. 
* Increased the default CPU request. 