### PR TITLE
Tune pcd sampling size

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1595,13 +1595,23 @@ deploymentSpec:
           \ *\n\ndef sdg_op(\n    num_instructions_to_generate: int,\n    pipeline:\
           \ str,\n    taxonomy: dsl.Input[dsl.Dataset],\n    sdg: dsl.Output[dsl.Dataset],\n\
           \    repo_branch: Optional[str],\n    repo_pr: Optional[int],\n):\n    from\
-          \ os import getenv\n\n    import openai\n    from instructlab.sdg import\
-          \ generate_data\n    from instructlab.sdg.utils.taxonomy import read_taxonomy\n\
-          \n    api_key = getenv(\"api_key\")\n    model = getenv(\"model\")\n   \
-          \ endpoint = getenv(\"endpoint\")\n    client = openai.OpenAI(base_url=endpoint,\
-          \ api_key=api_key)\n\n    taxonomy_base = \"main\" if repo_branch or (repo_pr\
-          \ and int(repo_pr) > 0) else \"empty\"\n\n    print(\"Generating syntetic\
-          \ dataset for:\")\n    print()\n    print(read_taxonomy(taxonomy.path, taxonomy_base))\n\
+          \ os import getenv, path\n\n    import openai\n    import yaml\n    from\
+          \ instructlab.sdg import generate_data\n    from instructlab.sdg.utils.taxonomy\
+          \ import read_taxonomy\n\n    SAMPLING_SIZE = 70\n\n    def set_precomputed_skills_data_ratio(sampling_size):\n\
+          \        skills_recipe = \"/usr/share/instructlab/sdg/default_data_recipes/skills.yaml\"\
+          \n        if path.exists(skills_recipe):\n            with open(skills_recipe,\
+          \ \"r\") as file:\n                skills_yaml = yaml.load(file, Loader=yaml.Loader)\n\
+          \n            skills_yaml[\"datasets\"][0][\"sampling_size\"] = sampling_size\n\
+          \n            with open(skills_recipe, \"w\", encoding=\"utf-8\") as file:\n\
+          \                yaml.dump(skills_yaml, file)\n\n    api_key = getenv(\"\
+          api_key\")\n    model = getenv(\"model\")\n    endpoint = getenv(\"endpoint\"\
+          )\n    client = openai.OpenAI(base_url=endpoint, api_key=api_key)\n\n  \
+          \  taxonomy_base = \"main\" if repo_branch or (repo_pr and int(repo_pr)\
+          \ > 0) else \"empty\"\n\n    print(\"Generating syntetic dataset for:\"\
+          )\n    print()\n    print(read_taxonomy(taxonomy.path, taxonomy_base))\n\
+          \n    # Temporary measure to limit the amount of precomputed skills data\
+          \ used to construct the SDG dataset.\n    # Need during development to decrease\
+          \ training loop times and the cost of model quality.\n    set_precomputed_skills_data_ratio(sampling_size=SAMPLING_SIZE)\n\
           \n    # generate_data has a magic word for its taxonomy_base argument -\
           \ 'empty'\n    # it allows generating from the whole repo, see:\n    # https://github.com/instructlab/sdg/blob/c6a9e74a1618b1077cd38e713b8aaed8b7c0c8ce/src/instructlab/sdg/utils/taxonomy.py#L230\n\
           \    generate_data(\n        client=client,\n        num_instructions_to_generate=num_instructions_to_generate,\n\


### PR DESCRIPTION
This PR allows developers to tune how much data is used from the default data skills recipe. This is useful when testing the whole iLab pipeline and model performance is not a concern.  `SAMPLING_SIZE` should be set to 1.0 in a production setting. 