### PR TITLE
feat: pass data between tasks via PVCs

### DIFF
--- a/eval/final/components.py
+++ b/eval/final/components.py
@@ -2,7 +2,7 @@
 # pylint: disable=no-value-for-parameter,import-outside-toplevel,import-error
 from typing import List, NamedTuple
 
-from kfp.dsl import Artifact, Dataset, Input, Model, Output, component, importer
+from kfp.dsl import Artifact, Output, component
 
 from utils.consts import PYTHON_IMAGE, RHELAI_IMAGE
 
@@ -14,8 +14,6 @@ def run_final_eval_op(
     mmlu_branch_output: Output[Artifact],
     mt_bench_branch_output: Output[Artifact],
     base_model_dir: str,
-    tasks: Input[Dataset],
-    taxonomy: Input[Dataset],
     base_branch: str,
     candidate_branch: str,
     max_workers: str,
@@ -25,6 +23,8 @@ def run_final_eval_op(
     batch_size: str,
     merge_system_user_message: bool,
     candidate_model: str = None,
+    taxonomy_path: str = "/input/taxonomy",
+    sdg_path: str = "/input/sdg",
 ):
     import json
     import os
@@ -272,7 +272,7 @@ def run_final_eval_op(
 
     mmlu_tasks = ["mmlu_pr"]
 
-    node_dataset_dirs = find_node_dataset_directories(tasks.path)
+    node_dataset_dirs = find_node_dataset_directories(sdg_path)
 
     # This assumes generated filesystem from ilab sdg, which
     # generates a node_datasets_ directory for MMLU custom tasks data
@@ -373,7 +373,7 @@ def run_final_eval_op(
         MTBenchBranchEvaluator(
             model_name=candidate_model,
             judge_model_name=judge_model_name,
-            taxonomy_git_repo_path=taxonomy.path,
+            taxonomy_git_repo_path=taxonomy_path,
             branch=candidate_branch,
             output_dir=output_dir,
             merge_system_user_message=merge_system_user_message,
@@ -381,7 +381,7 @@ def run_final_eval_op(
         MTBenchBranchEvaluator(
             model_name=base_model_dir,
             judge_model_name=judge_model_name,
-            taxonomy_git_repo_path=taxonomy.path,
+            taxonomy_git_repo_path=taxonomy_path,
             branch=base_branch,
             output_dir=output_dir,
             merge_system_user_message=merge_system_user_message,

--- a/eval/final/components.py
+++ b/eval/final/components.py
@@ -351,7 +351,7 @@ def run_final_eval_op(
 
     # MT_BENCH_BRANCH
 
-    print("Strating MT_BENCH_BRANCH ...")
+    print("Starting MT_BENCH_BRANCH ...")
 
     judge_api_key = os.getenv("JUDGE_API_KEY", "")
     judge_model_name = os.getenv("JUDGE_NAME")

--- a/eval/mt_bench/__init__.py
+++ b/eval/mt_bench/__init__.py
@@ -1,5 +1,5 @@
-from .components import load_mt_bench_results_op, run_mt_bench_op
+from .components import run_mt_bench_op
 
 # from . import faked
 
-__all__ = ["run_mt_bench_op", "load_mt_bench_results_op"]
+__all__ = ["run_mt_bench_op"]

--- a/eval/mt_bench/components.py
+++ b/eval/mt_bench/components.py
@@ -15,7 +15,7 @@ def run_mt_bench_op(
     # with 'auto', number of gpus allocated for serving is calculated based on environment
     # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36
     max_workers: str,
-    output_path: str = "/output",
+    output_path: str = "/output/mt_bench_data.json",
     models_list: List[str] = None,
     models_folder: Optional[str] = None,
     device: str = None,
@@ -203,7 +203,7 @@ def run_mt_bench_op(
         all_mt_bench_data.append(mt_bench_data)
         scores[model_path] = overall_score
 
-    with open(f"{output_path}/mt_bench_data.json", "w", encoding="utf-8") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(all_mt_bench_data, f, indent=4)
 
     outputs = NamedTuple("outputs", best_model=str, best_score=float)

--- a/eval/mt_bench/components.py
+++ b/eval/mt_bench/components.py
@@ -224,18 +224,3 @@ def run_mt_bench_op(
         )
 
     return outputs(best_model=best_model, best_score=best_score)
-
-
-@component(base_image=PYTHON_IMAGE)
-def load_mt_bench_results_op(mt_bench_output: Input[Artifact]) -> list:
-    import json
-
-    mt_bench_score_list = []
-    with open(mt_bench_output.path, "r") as f:
-        mt_bench_score_list = json.load(f)
-
-    print("MT_Bench Evaluation Data:")
-    for mt_bench_score in mt_bench_score_list:
-        print(json.dumps(mt_bench_score, indent=4))
-
-    return mt_bench_score_list

--- a/eval/mt_bench/components.py
+++ b/eval/mt_bench/components.py
@@ -2,20 +2,20 @@
 # pylint: disable=no-value-for-parameter,import-outside-toplevel,import-error
 from typing import List, NamedTuple, Optional
 
-from kfp.dsl import Artifact, Input, Model, Output, component, importer
+from kfp.dsl import component
 
-from utils.consts import PYTHON_IMAGE, RHELAI_IMAGE
+from utils.consts import RHELAI_IMAGE
 
 
 @component(base_image=RHELAI_IMAGE)
 def run_mt_bench_op(
     models_path_prefix: str,
-    mt_bench_output: Output[Artifact],
     merge_system_user_message: bool,
     # generate_answers,judgment uses a magic word for its mt_bench evaluator  - 'auto'
     # with 'auto', number of gpus allocated for serving is calculated based on environment
     # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36
     max_workers: str,
+    output_path: str = "/output",
     models_list: List[str] = None,
     models_folder: Optional[str] = None,
     device: str = None,
@@ -203,7 +203,7 @@ def run_mt_bench_op(
         all_mt_bench_data.append(mt_bench_data)
         scores[model_path] = overall_score
 
-    with open(mt_bench_output.path, "w", encoding="utf-8") as f:
+    with open(f"{output_path}/mt_bench_data.json", "w", encoding="utf-8") as f:
         json.dump(all_mt_bench_data, f, indent=4)
 
     outputs = NamedTuple("outputs", best_model=str, best_score=float)

--- a/pipeline.py
+++ b/pipeline.py
@@ -27,7 +27,6 @@ GENERATED_STANDALONE_FILE_NAME = "standalone.py"
 DEFAULT_REPO_URL = "https://github.com/instructlab/taxonomy.git"
 KFP_MODEL_SERVER_CM = "sdg/kfp-model-server.yaml"
 BASE_MODEL = "ibm-granite/granite-7b-base"
-BASE_MODEL_DIR = "/data/model/"  # <- "model ID for vLLM chat/completions - corresponds to path within pvc"
 
 # eval args
 MMLU_TASKS_LIST = "mmlu_anatomy,mmlu_astronomy"
@@ -423,7 +422,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             base_branch=repo_branch,
             candidate_branch=repo_branch,
             device=device,
-            base_model_dir=BASE_MODEL_DIR,
+            base_model_dir="/model",
             max_workers=max_workers,
             merge_system_user_message=merge_system_user_message,
             model_dtype=model_dtype,
@@ -440,8 +439,8 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
         )
         mount_pvc(
             task=final_eval_task,
-            pvc_name=sdg_input_pvc_task.output,
-            mount_path="/data",
+            pvc_name=model_pvc_task.output,
+            mount_path="/model",
         )
 
         use_config_map_as_env(

--- a/pipeline.py
+++ b/pipeline.py
@@ -141,7 +141,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
         sdg_input_pvc_task = CreatePVC(
             pvc_name_suffix="-sdg",
             access_modes=["ReadWriteMany"],
-            size="1Gi",
+            size="10Gi",
             storage_class_name=storage_class_name,
         )
         git_clone_task = git_clone_op(
@@ -555,7 +555,7 @@ def gen_standalone():
         "exec-sdg-op": 'sdg_op(num_instructions_to_generate={num_instructions_to_generate}, pipeline="{sdg_pipeline}", repo_branch="{exec_git_clone_op_repo_branch}", repo_pr={exec_git_clone_op_repo_pr}, taxonomy_path="{TAXONOMY_DATA_PATH}", sdg_path="{DATA_PVC_SDG_PATH}")',
         "exec-git-clone-op": {},
         "exec-huggingface-importer-op": 'huggingface_importer_op(repo_name="{REPO_GRANITE_7B_IMAGE}", model_path="{DATA_PVC_MODEL_PATH}")',
-        "exec-run-mt-bench-op": 'run_mt_bench_op(best_score_file="{MT_BENCH_SCORES_PATH}",mt_bench_output="{MT_BENCH_OUTPUT_PATH}",models_folder="{CANDIDATE_MODEL_PATH_PREFIX}",models_path_prefix="{CANDIDATE_MODEL_PATH_PREFIX}", max_workers="{MAX_WORKERS}", merge_system_user_message={MERGE_SYSTEM_USER_MESSAGE})',
+        "exec-run-mt-bench-op": 'run_mt_bench_op(best_score_file="{MT_BENCH_SCORES_PATH}",output_path="{MT_BENCH_OUTPUT_PATH}",models_folder="{CANDIDATE_MODEL_PATH_PREFIX}",models_path_prefix="{CANDIDATE_MODEL_PATH_PREFIX}", max_workers="{MAX_WORKERS}", merge_system_user_message={MERGE_SYSTEM_USER_MESSAGE})',
         "exec-run-final-eval-op": 'run_final_eval_op(mmlu_branch_output="{MMLU_BRANCH_SCORES_PATH}", mt_bench_branch_output="{MT_BENCH_BRANCH_SCORES_PATH}", candidate_model="{CANDIDATE_MODEL_PATH}", taxonomy_path="{TAXONOMY_PATH}", sdg_path="{DATA_PVC_SDG_PATH}", base_branch="", candidate_branch="", device=None, base_model_dir="{DATA_PVC_MODEL_PATH}", max_workers="{MAX_WORKERS}", merge_system_user_message={MERGE_SYSTEM_USER_MESSAGE}, model_dtype="{MODEL_DTYPE}", few_shots={FEW_SHOTS}, batch_size="{BATCH_SIZE}")',
     }
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -422,7 +422,7 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             base_branch=repo_branch,
             candidate_branch=repo_branch,
             device=device,
-            base_model_dir="/model",
+            base_model_dir="/model/",
             max_workers=max_workers,
             merge_system_user_message=merge_system_user_message,
             model_dtype=model_dtype,

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2027,6 +2027,7 @@ root:
           name: comp-run-final-eval-op
         dependentTasks:
         - createpvc
+        - createpvc-2
         - createpvc-3
         - run-mt-bench-op
         inputs:
@@ -2035,7 +2036,7 @@ root:
               componentInputParameter: repo_branch
             base_model_dir:
               runtimeValue:
-                constant: /data/model/
+                constant: /model
             batch_size:
               componentInputParameter: batch_size
             candidate_branch:
@@ -2298,10 +2299,10 @@ platforms:
             taskOutputParameter:
               outputParameterKey: name
               producerTask: createpvc
-          - mountPath: /data
+          - mountPath: /model
             taskOutputParameter:
               outputParameterKey: name
-              producerTask: createpvc
+              producerTask: createpvc-2
           secretAsEnv:
           - keyToEnv:
             - envVar: JUDGE_API_KEY

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -341,18 +341,6 @@ components:
       parameters:
         Output:
           parameterType: LIST
-  comp-pvc-to-artifact-op:
-    executorLabel: exec-pvc-to-artifact-op
-    inputDefinitions:
-      parameters:
-        pvc_path:
-          parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        model:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
   comp-pvc-to-model-op:
     executorLabel: exec-pvc-to-model-op
     inputDefinitions:
@@ -364,6 +352,18 @@ components:
         model:
           artifactType:
             schemaTitle: system.Model
+            schemaVersion: 0.0.1
+  comp-pvc-to-mt-bench-op:
+    executorLabel: exec-pvc-to-mt-bench-op
+    inputDefinitions:
+      parameters:
+        pvc_path:
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        mt_bench_output:
+          artifactType:
+            schemaTitle: system.Artifact
             schemaVersion: 0.0.1
   comp-pytorchjob-manifest-op:
     executorLabel: exec-pytorchjob-manifest-op
@@ -542,12 +542,11 @@ components:
           parameterType: LIST
         models_path_prefix:
           parameterType: STRING
+        output_path:
+          defaultValue: /output
+          isOptional: true
+          parameterType: STRING
     outputDefinitions:
-      artifacts:
-        mt_bench_output:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
       parameters:
         best_model:
           parameterType: STRING
@@ -820,11 +819,11 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef list_models_in_directory_op(models_folder: str) -> List:\n  \
-          \  import os\n\n    models = os.listdir(models_folder)\n    return models\n\
+          \ *\n\ndef list_models_in_directory_op(models_folder: str) -> List[str]:\n\
+          \    import os\n\n    models = os.listdir(models_folder)\n    return models\n\
           \n"
         image: python:3.8
-    exec-pvc-to-artifact-op:
+    exec-pvc-to-model-op:
       container:
         args:
         - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['model'].path}}
@@ -832,10 +831,10 @@ deploymentSpec:
         - /bin/sh
         - -c
         image: registry.access.redhat.com/ubi9/toolbox
-    exec-pvc-to-model-op:
+    exec-pvc-to-mt-bench-op:
       container:
         args:
-        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['model'].path}}
+        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['mt_bench_output'].path}}
         command:
         - /bin/sh
         - -c
@@ -1445,47 +1444,46 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef run_mt_bench_op(\n    models_path_prefix: str,\n    mt_bench_output:\
-          \ Output[Artifact],\n    merge_system_user_message: bool,\n    # generate_answers,judgment\
-          \ uses a magic word for its mt_bench evaluator  - 'auto'\n    # with 'auto',\
-          \ number of gpus allocated for serving is calculated based on environment\n\
-          \    # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36\n\
-          \    max_workers: str,\n    models_list: List[str] = None,\n    models_folder:\
-          \ Optional[str] = None,\n    device: str = None,\n    best_score_file: Optional[str]\
-          \ = None,\n) -> NamedTuple(\"outputs\", best_model=str, best_score=float):\n\
-          \    import json\n    import os\n    import subprocess\n\n    import torch\n\
-          \    from instructlab.eval.mt_bench import MTBenchEvaluator\n\n    if judge_ca_cert\
-          \ := os.getenv(\"JUDGE_CA_CERT_PATH\"):\n        import httpx\n        import\
-          \ openai\n\n        # Create a custom HTTP client\n        class CustomHttpClient(httpx.Client):\n\
-          \            def __init__(self, *args, **kwargs):\n                # Use\
-          \ the custom CA certificate\n                kwargs.setdefault(\"verify\"\
-          , judge_ca_cert)\n                super().__init__(*args, **kwargs)\n\n\
-          \        # Create a new OpenAI class that uses the custom HTTP client\n\
-          \        class CustomOpenAI(openai.OpenAI):\n            def __init__(self,\
-          \ *args, **kwargs):\n                custom_client = CustomHttpClient()\n\
-          \                super().__init__(http_client=custom_client, *args, **kwargs)\n\
-          \n        # Monkey patch the OpenAI class in the openai module, so that\
-          \ the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\n    def\
-          \ launch_vllm(\n        model_path: str, gpu_count: int, retries: int =\
-          \ 120, delay: int = 10\n    ) -> tuple:\n        import subprocess\n   \
-          \     import sys\n        import time\n\n        import requests\n     \
-          \   from instructlab.model.backends.common import free_tcp_ipv4_port\n\n\
-          \        free_port = free_tcp_ipv4_port(\"127.0.0.1\")\n        port = str(free_port)\n\
-          \        vllm_server = f\"http://127.0.0.1:{port}/v1\"\n\n        command\
-          \ = [\n            sys.executable,\n            \"-m\",\n            \"\
-          vllm.entrypoints.openai.api_server\",\n            \"--port\",\n       \
-          \     port,\n            \"--model\",\n            model_path,\n       \
-          \ ]\n        if gpu_count > 0:\n            command += [\n             \
-          \   \"--tensor-parallel-size\",\n                str(gpu_count),\n     \
-          \       ]\n\n        process = subprocess.Popen(args=command)\n\n      \
-          \  print(f\"Waiting for vLLM server to start at {vllm_server}...\")\n\n\
-          \        for attempt in range(retries):\n            try:\n            \
-          \    response = requests.get(f\"{vllm_server}/models\")\n              \
-          \  if response.status_code == 200:\n                    print(f\"vLLM server\
-          \ is up and running at {vllm_server}.\")\n                    return process,\
-          \ vllm_server\n            except requests.ConnectionError:\n          \
-          \      pass\n\n            print(\n                f\"Server not available\
-          \ yet, retrying in {delay} seconds (Attempt {attempt + 1}/{retries})...\"\
+          \ *\n\ndef run_mt_bench_op(\n    models_path_prefix: str,\n    merge_system_user_message:\
+          \ bool,\n    # generate_answers,judgment uses a magic word for its mt_bench\
+          \ evaluator  - 'auto'\n    # with 'auto', number of gpus allocated for serving\
+          \ is calculated based on environment\n    # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36\n\
+          \    max_workers: str,\n    output_path: str = \"/output\",\n    models_list:\
+          \ List[str] = None,\n    models_folder: Optional[str] = None,\n    device:\
+          \ str = None,\n    best_score_file: Optional[str] = None,\n) -> NamedTuple(\"\
+          outputs\", best_model=str, best_score=float):\n    import json\n    import\
+          \ os\n    import subprocess\n\n    import torch\n    from instructlab.eval.mt_bench\
+          \ import MTBenchEvaluator\n\n    if judge_ca_cert := os.getenv(\"JUDGE_CA_CERT_PATH\"\
+          ):\n        import httpx\n        import openai\n\n        # Create a custom\
+          \ HTTP client\n        class CustomHttpClient(httpx.Client):\n         \
+          \   def __init__(self, *args, **kwargs):\n                # Use the custom\
+          \ CA certificate\n                kwargs.setdefault(\"verify\", judge_ca_cert)\n\
+          \                super().__init__(*args, **kwargs)\n\n        # Create a\
+          \ new OpenAI class that uses the custom HTTP client\n        class CustomOpenAI(openai.OpenAI):\n\
+          \            def __init__(self, *args, **kwargs):\n                custom_client\
+          \ = CustomHttpClient()\n                super().__init__(http_client=custom_client,\
+          \ *args, **kwargs)\n\n        # Monkey patch the OpenAI class in the openai\
+          \ module, so that the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\
+          \n    def launch_vllm(\n        model_path: str, gpu_count: int, retries:\
+          \ int = 120, delay: int = 10\n    ) -> tuple:\n        import subprocess\n\
+          \        import sys\n        import time\n\n        import requests\n  \
+          \      from instructlab.model.backends.common import free_tcp_ipv4_port\n\
+          \n        free_port = free_tcp_ipv4_port(\"127.0.0.1\")\n        port =\
+          \ str(free_port)\n        vllm_server = f\"http://127.0.0.1:{port}/v1\"\n\
+          \n        command = [\n            sys.executable,\n            \"-m\",\n\
+          \            \"vllm.entrypoints.openai.api_server\",\n            \"--port\"\
+          ,\n            port,\n            \"--model\",\n            model_path,\n\
+          \        ]\n        if gpu_count > 0:\n            command += [\n      \
+          \          \"--tensor-parallel-size\",\n                str(gpu_count),\n\
+          \            ]\n\n        process = subprocess.Popen(args=command)\n\n \
+          \       print(f\"Waiting for vLLM server to start at {vllm_server}...\"\
+          )\n\n        for attempt in range(retries):\n            try:\n        \
+          \        response = requests.get(f\"{vllm_server}/models\")\n          \
+          \      if response.status_code == 200:\n                    print(f\"vLLM\
+          \ server is up and running at {vllm_server}.\")\n                    return\
+          \ process, vllm_server\n            except requests.ConnectionError:\n \
+          \               pass\n\n            print(\n                f\"Server not\
+          \ available yet, retrying in {delay} seconds (Attempt {attempt + 1}/{retries})...\"\
           \n            )\n            time.sleep(delay)\n\n        raise RuntimeError(\n\
           \            f\"Failed to start vLLM server at {vllm_server} after {retries}\
           \ retries.\"\n        )\n\n    def shutdown_vllm(process: subprocess.Popen,\
@@ -1541,15 +1539,15 @@ deploymentSpec:
           : overall_score,\n            \"turn_scores\": turn_scores,\n          \
           \  \"qa_scores\": qa_pairs,\n            \"error_rate\": error_rate,\n \
           \       }\n\n        all_mt_bench_data.append(mt_bench_data)\n        scores[model_path]\
-          \ = overall_score\n\n    with open(mt_bench_output.path, \"w\", encoding=\"\
-          utf-8\") as f:\n        json.dump(all_mt_bench_data, f, indent=4)\n\n  \
-          \  outputs = NamedTuple(\"outputs\", best_model=str, best_score=float)\n\
-          \    best_model = max(scores, key=scores.get)\n    best_score = scores[best_model]\n\
-          \    if best_score_file:\n        with open(best_score_file, \"w\", encoding=\"\
-          utf-8\") as f:\n            json.dump({\"best_model\": best_model, \"best_score\"\
-          : best_score}, f, indent=4)\n\n    # Rename the best model directory to\
-          \ \"candidate_model\" for the next step\n    # So we know which model to\
-          \ use for the final evaluation\n    if os.path.exists(os.path.join(models_path_prefix,\
+          \ = overall_score\n\n    with open(f\"{output_path}/mt_bench_data.json\"\
+          , \"w\", encoding=\"utf-8\") as f:\n        json.dump(all_mt_bench_data,\
+          \ f, indent=4)\n\n    outputs = NamedTuple(\"outputs\", best_model=str,\
+          \ best_score=float)\n    best_model = max(scores, key=scores.get)\n    best_score\
+          \ = scores[best_model]\n    if best_score_file:\n        with open(best_score_file,\
+          \ \"w\", encoding=\"utf-8\") as f:\n            json.dump({\"best_model\"\
+          : best_model, \"best_score\": best_score}, f, indent=4)\n\n    # Rename\
+          \ the best model directory to \"candidate_model\" for the next step\n  \
+          \  # So we know which model to use for the final evaluation\n    if os.path.exists(os.path.join(models_path_prefix,\
           \ \"candidate_model\")):\n        print(\"candidate_model already exists.\
           \ Skipping renaming\")\n    else:\n        os.rename(\n            os.path.join(models_path_prefix,\
           \ best_model),\n            os.path.join(models_path_prefix, \"candidate_model\"\
@@ -1725,8 +1723,9 @@ root:
           name: comp-deletepvc
         dependentTasks:
         - createpvc-3
-        - pvc-to-artifact-op
         - pvc-to-model-op
+        - pvc-to-mt-bench-op
+        - run-final-eval-op
         inputs:
           parameters:
             pvc_name:
@@ -1742,8 +1741,7 @@ root:
           name: comp-deletepvc-2
         dependentTasks:
         - createpvc
-        - pvc-to-artifact-op
-        - pvc-to-model-op
+        - run-final-eval-op
         inputs:
           parameters:
             pvc_name:
@@ -1759,8 +1757,7 @@ root:
           name: comp-deletepvc-3
         dependentTasks:
         - createpvc-2
-        - pvc-to-artifact-op
-        - pvc-to-model-op
+        - run-final-eval-op
         inputs:
           parameters:
             pvc_name:
@@ -1892,20 +1889,6 @@ root:
                 constant: /output/phase_2/model/hf_format
         taskInfo:
           name: list-models-in-directory-op
-      pvc-to-artifact-op:
-        cachingOptions: {}
-        componentRef:
-          name: comp-pvc-to-artifact-op
-        dependentTasks:
-        - createpvc-3
-        - run-final-eval-op
-        inputs:
-          parameters:
-            pvc_path:
-              runtimeValue:
-                constant: /output/data
-        taskInfo:
-          name: pvc-to-artifact-op
       pvc-to-model-op:
         cachingOptions:
           enableCache: true
@@ -1913,14 +1896,29 @@ root:
           name: comp-pvc-to-model-op
         dependentTasks:
         - createpvc-3
-        - run-final-eval-op
+        - run-mt-bench-op
         inputs:
           parameters:
             pvc_path:
               runtimeValue:
-                constant: /output/model
+                constant: /output/phase_2/model/hf_format/candidate_model
         taskInfo:
           name: pvc-to-model-op
+      pvc-to-mt-bench-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-pvc-to-mt-bench-op
+        dependentTasks:
+        - createpvc-3
+        - run-mt-bench-op
+        inputs:
+          parameters:
+            pvc_path:
+              runtimeValue:
+                constant: /output/mt_bench_data.json
+        taskInfo:
+          name: pvc-to-mt-bench-op
       pytorchjob-manifest-op:
         cachingOptions: {}
         componentRef:
@@ -2262,15 +2260,15 @@ platforms:
             taskOutputParameter:
               outputParameterKey: name
               producerTask: createpvc-3
-        exec-pvc-to-artifact-op:
+        exec-pvc-to-model-op:
           pvcMount:
-          - mountPath: /output/data
+          - mountPath: /output
             taskOutputParameter:
               outputParameterKey: name
               producerTask: createpvc-3
-        exec-pvc-to-model-op:
+        exec-pvc-to-mt-bench-op:
           pvcMount:
-          - mountPath: /output/model
+          - mountPath: /output
             taskOutputParameter:
               outputParameterKey: name
               producerTask: createpvc-3

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -26,39 +26,6 @@
 #    seed: int [Default: 42.0]
 #    storage_class_name: str [Default: 'nfs-csi']
 components:
-  comp-artifact-to-pvc-op:
-    executorLabel: exec-artifact-to-pvc-op
-    inputDefinitions:
-      artifacts:
-        data:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-      parameters:
-        pvc_path:
-          parameterType: STRING
-  comp-artifact-to-pvc-op-2:
-    executorLabel: exec-artifact-to-pvc-op-2
-    inputDefinitions:
-      artifacts:
-        data:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-      parameters:
-        pvc_path:
-          parameterType: STRING
-  comp-artifact-to-pvc-op-3:
-    executorLabel: exec-artifact-to-pvc-op-3
-    inputDefinitions:
-      artifacts:
-        data:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-      parameters:
-        pvc_path:
-          parameterType: STRING
   comp-createpvc:
     executorLabel: exec-createpvc
     inputDefinitions:
@@ -245,16 +212,11 @@ components:
   comp-data-processing-op:
     executorLabel: exec-data-processing-op
     inputDefinitions:
-      artifacts:
-        model:
-          artifactType:
-            schemaTitle: system.Artifact
-            schemaVersion: 0.0.1
-        sdg:
-          artifactType:
-            schemaTitle: system.Dataset
-            schemaVersion: 0.0.1
       parameters:
+        knowledge_path:
+          defaultValue: /data/knowledge
+          isOptional: true
+          parameterType: STRING
         max_batch_len:
           defaultValue: 20000.0
           isOptional: true
@@ -263,16 +225,18 @@ components:
           defaultValue: 4096.0
           isOptional: true
           parameterType: NUMBER_INTEGER
-    outputDefinitions:
-      artifacts:
-        knowledge_processed_data:
-          artifactType:
-            schemaTitle: system.Dataset
-            schemaVersion: 0.0.1
-        skills_processed_data:
-          artifactType:
-            schemaTitle: system.Dataset
-            schemaVersion: 0.0.1
+        model_path:
+          defaultValue: /model
+          isOptional: true
+          parameterType: STRING
+        sdg_path:
+          defaultValue: /data/sdg
+          isOptional: true
+          parameterType: STRING
+        skills_path:
+          defaultValue: /data/skills
+          isOptional: true
+          parameterType: STRING
   comp-deletepvc:
     executorLabel: exec-deletepvc
     inputDefinitions:
@@ -307,23 +271,33 @@ components:
           parameterType: NUMBER_INTEGER
         repo_url:
           parameterType: STRING
-    outputDefinitions:
-      artifacts:
-        taxonomy:
-          artifactType:
-            schemaTitle: system.Dataset
-            schemaVersion: 0.0.1
+        taxonomy_path:
+          defaultValue: /data/taxonomy
+          isOptional: true
+          parameterType: STRING
   comp-huggingface-importer-op:
     executorLabel: exec-huggingface-importer-op
     inputDefinitions:
       parameters:
+        model_path:
+          defaultValue: /model
+          isOptional: true
+          parameterType: STRING
         repo_name:
+          parameterType: STRING
+  comp-knowledge-processed-data-to-artifact-op:
+    executorLabel: exec-knowledge-processed-data-to-artifact-op
+    inputDefinitions:
+      parameters:
+        pvc_path:
+          defaultValue: /data/knowledge
+          isOptional: true
           parameterType: STRING
     outputDefinitions:
       artifacts:
-        model:
+        knowledge_processed_data:
           artifactType:
-            schemaTitle: system.Model
+            schemaTitle: system.Dataset
             schemaVersion: 0.0.1
   comp-kubectl-apply-op:
     executorLabel: exec-kubectl-apply-op
@@ -506,15 +480,6 @@ components:
   comp-run-final-eval-op:
     executorLabel: exec-run-final-eval-op
     inputDefinitions:
-      artifacts:
-        tasks:
-          artifactType:
-            schemaTitle: system.Dataset
-            schemaVersion: 0.0.1
-        taxonomy:
-          artifactType:
-            schemaTitle: system.Dataset
-            schemaVersion: 0.0.1
       parameters:
         base_branch:
           parameterType: STRING
@@ -536,6 +501,14 @@ components:
         merge_system_user_message:
           parameterType: BOOLEAN
         model_dtype:
+          parameterType: STRING
+        sdg_path:
+          defaultValue: /input/sdg
+          isOptional: true
+          parameterType: STRING
+        taxonomy_path:
+          defaultValue: /input/taxonomy
+          isOptional: true
           parameterType: STRING
     outputDefinitions:
       artifacts:
@@ -583,11 +556,6 @@ components:
   comp-sdg-op:
     executorLabel: exec-sdg-op
     inputDefinitions:
-      artifacts:
-        taxonomy:
-          artifactType:
-            schemaTitle: system.Dataset
-            schemaVersion: 0.0.1
       parameters:
         num_instructions_to_generate:
           parameterType: NUMBER_INTEGER
@@ -597,38 +565,58 @@ components:
           parameterType: STRING
         repo_pr:
           parameterType: NUMBER_INTEGER
+        sdg_path:
+          defaultValue: /data/sdg
+          isOptional: true
+          parameterType: STRING
+        taxonomy_path:
+          defaultValue: /data/taxonomy
+          isOptional: true
+          parameterType: STRING
+  comp-sdg-to-artifact-op:
+    executorLabel: exec-sdg-to-artifact-op
+    inputDefinitions:
+      parameters:
+        pvc_path:
+          defaultValue: /data/sdg
+          isOptional: true
+          parameterType: STRING
     outputDefinitions:
       artifacts:
         sdg:
           artifactType:
             schemaTitle: system.Dataset
             schemaVersion: 0.0.1
+  comp-skills-processed-data-to-artifact-op:
+    executorLabel: exec-skills-processed-data-to-artifact-op
+    inputDefinitions:
+      parameters:
+        pvc_path:
+          defaultValue: /data/skills
+          isOptional: true
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        skills_processed_data:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
+  comp-taxonomy-to-artifact-op:
+    executorLabel: exec-taxonomy-to-artifact-op
+    inputDefinitions:
+      parameters:
+        pvc_path:
+          defaultValue: /data/taxonomy
+          isOptional: true
+          parameterType: STRING
+    outputDefinitions:
+      artifacts:
+        taxonomy:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
 deploymentSpec:
   executors:
-    exec-artifact-to-pvc-op:
-      container:
-        args:
-        - cp -r {{$.inputs.artifacts['data'].path}} {{$.inputs.parameters['pvc_path']}}
-        command:
-        - /bin/sh
-        - -c
-        image: registry.access.redhat.com/ubi9/toolbox
-    exec-artifact-to-pvc-op-2:
-      container:
-        args:
-        - cp -r {{$.inputs.artifacts['data'].path}} {{$.inputs.parameters['pvc_path']}}
-        command:
-        - /bin/sh
-        - -c
-        image: registry.access.redhat.com/ubi9/toolbox
-    exec-artifact-to-pvc-op-3:
-      container:
-        args:
-        - cp -r {{$.inputs.artifacts['data'].path}} {{$.inputs.parameters['pvc_path']}}
-        command:
-        - /bin/sh
-        - -c
-        image: registry.access.redhat.com/ubi9/toolbox
     exec-createpvc:
       container:
         image: argostub/createpvc
@@ -665,15 +653,15 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef data_processing_op(\n    sdg: dsl.Input[dsl.Dataset],\n    skills_processed_data:\
-          \ dsl.Output[dsl.Dataset],\n    knowledge_processed_data: dsl.Output[dsl.Dataset],\n\
-          \    model: dsl.Input[dsl.Artifact],\n    max_seq_len: Optional[int] = 4096,\n\
-          \    max_batch_len: Optional[int] = 20000,\n):\n    import os\n\n    import\
+          \ *\n\ndef data_processing_op(\n    model_path: str = \"/model\",\n    sdg_path:\
+          \ str = \"/data/sdg\",\n    skills_path: str = \"/data/skills\",\n    knowledge_path:\
+          \ str = \"/data/knowledge\",\n    max_seq_len: Optional[int] = 4096,\n \
+          \   max_batch_len: Optional[int] = 20000,\n):\n    import os\n\n    import\
           \ instructlab.training.data_process as dp\n    from instructlab.training\
           \ import (\n        DataProcessArgs,\n        TrainingArgs,\n    )\n\n \
           \   # define training-specific arguments\n    skill_training_args = TrainingArgs(\n\
-          \        # define data-specific arguments\n        model_path=model.path,\n\
-          \        data_path=f\"{sdg.path}/skills_train_msgs*.jsonl\",\n        data_output_dir=skills_processed_data.path,\n\
+          \        # define data-specific arguments\n        model_path=model_path,\n\
+          \        data_path=f\"{sdg_path}/skills_train_msgs*.jsonl\",\n        data_output_dir=skills_path,\n\
           \        # define model-trianing parameters\n        max_seq_len=max_seq_len,\n\
           \        max_batch_len=max_batch_len,\n        # XXX(shanand): We don't\
           \ need the following arguments\n        # for data processing. Added them\
@@ -682,9 +670,9 @@ deploymentSpec:
           \        effective_batch_size=3840,\n        save_samples=0,\n        learning_rate=2e-6,\n\
           \        warmup_steps=800,\n        is_padding_free=True,\n    )\n\n   \
           \ knowledge_training_args = TrainingArgs(\n        # define data-specific\
-          \ arguments\n        model_path=model.path,\n        data_path=f\"{sdg.path}/knowledge_train_msgs*.jsonl\"\
-          ,\n        data_output_dir=knowledge_processed_data.path,\n        # define\
-          \ model-trianing parameters\n        max_seq_len=max_seq_len,\n        max_batch_len=max_batch_len,\n\
+          \ arguments\n        model_path=model_path,\n        data_path=f\"{sdg_path}/knowledge_train_msgs*.jsonl\"\
+          ,\n        data_output_dir=knowledge_path,\n        # define model-trianing\
+          \ parameters\n        max_seq_len=max_seq_len,\n        max_batch_len=max_batch_len,\n\
           \        # XXX(shanand): We don't need the following arguments\n       \
           \ # for data processing. Added them for now to avoid\n        # Pydantic\
           \ validation errors for TrainingArgs\n        ckpt_output_dir=\"data/saved_checkpoints\"\
@@ -722,8 +710,8 @@ deploymentSpec:
     exec-git-clone-op:
       container:
         args:
-        - 'git clone {{$.inputs.parameters[''repo_url'']}} {{$.outputs.artifacts[''taxonomy''].path}}
-          && cd {{$.outputs.artifacts[''taxonomy''].path}} && if [ -n "{{$.inputs.parameters[''repo_branch'']}}"
+        - 'git clone {{$.inputs.parameters[''repo_url'']}} {{$.inputs.parameters[''taxonomy_path'']}}
+          && cd {{$.inputs.parameters[''taxonomy_path'']}} && if [ -n "{{$.inputs.parameters[''repo_branch'']}}"
           ]; then git fetch origin {{$.inputs.parameters[''repo_branch'']}} && git
           checkout {{$.inputs.parameters[''repo_branch'']}}; elif [ -n "{{$.inputs.parameters[''repo_pr'']}}"
           ] && [ {{$.inputs.parameters[''repo_pr'']}} -gt 0 ]; then git fetch origin
@@ -760,10 +748,18 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef huggingface_importer_op(model: dsl.Output[dsl.Model], repo_name:\
-          \ str):\n    from huggingface_hub import snapshot_download\n\n    snapshot_download(repo_id=repo_name,\
-          \ cache_dir=\"/tmp\", local_dir=model.path)\n\n"
+          \ *\n\ndef huggingface_importer_op(repo_name: str, model_path: str = \"\
+          /model\"):\n    from huggingface_hub import snapshot_download\n\n    snapshot_download(repo_id=repo_name,\
+          \ cache_dir=\"/tmp\", local_dir=model_path)\n\n"
         image: registry.access.redhat.com/ubi9/python-311:latest
+    exec-knowledge-processed-data-to-artifact-op:
+      container:
+        args:
+        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['knowledge_processed_data'].path}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
     exec-kubectl-apply-op:
       container:
         args:
@@ -884,19 +880,20 @@ deploymentSpec:
           \      newest_model = models[newest_idx]\n        return f\"{model_dir}/{newest_model}\"\
           \n\n    Outputs = NamedTuple(\"outputs\", manifest=str, name=str)\n    name\
           \ = f\"train-phase-{phase_num}-{name_suffix.rstrip('-sdg')}\"\n\n    if\
-          \ phase_num == 1:\n        path_to_model = \"/input_model/model\"\n    \
-          \    path_to_data = \"/input_data/knowledge_processed_data/data.jsonl\"\n\
-          \    elif phase_num == 2:\n        path_to_model = list_phase1_final_model()\n\
-          \        path_to_data = \"/input_data/skills_processed_data/data.jsonl\"\
-          \n\n    image = \"quay.io/redhat-et/ilab:1.2\"\n\n    manifest = inspect.cleandoc(\n\
-          \        f\"\"\"\n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n\
-          \        metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
-          \ \\\\\"{nproc_per_node}\\\\\"\n          pytorchReplicaSpecs:\n       \
-          \     Master:\n              replicas: 1\n              restartPolicy: OnFailure\n\
-          \              template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  containers:\n                    - args:\n          \
-          \              - |\n                          echo \"Running phase {phase_num}\"\
+          \ phase_num == 1:\n        path_to_model = \"/input_model\"\n        path_to_data\
+          \ = \"/input_data/knowledge/data.jsonl\"\n    elif phase_num == 2:\n   \
+          \     path_to_model = list_phase1_final_model()\n        path_to_data =\
+          \ \"/input_data/skills/data.jsonl\"\n    else:\n        raise RuntimeError(f\"\
+          Unsupported value of {phase_num=}\")\n\n    image = \"quay.io/redhat-et/ilab:1.2\"\
+          \n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
+          \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
+          \   name: {name}\n        spec:\n          nprocPerNode: \\\\\"{nproc_per_node}\\\
+          \\\"\n          pytorchReplicaSpecs:\n            Master:\n            \
+          \  replicas: 1\n              restartPolicy: OnFailure\n              template:\n\
+          \                metadata:\n                  annotations:\n           \
+          \         sidecar.istio.io/inject: 'false'\n                spec:\n    \
+          \              containers:\n                    - args:\n              \
+          \          - |\n                          echo \"Running phase {phase_num}\"\
           \n                          echo \"Using {path_to_model} model for training\"\
           \n                          echo \"Using {path_to_data} data for training\"\
           \n                          mkdir -p /output/phase_{phase_num}/model;\n\
@@ -1040,19 +1037,20 @@ deploymentSpec:
           \      newest_model = models[newest_idx]\n        return f\"{model_dir}/{newest_model}\"\
           \n\n    Outputs = NamedTuple(\"outputs\", manifest=str, name=str)\n    name\
           \ = f\"train-phase-{phase_num}-{name_suffix.rstrip('-sdg')}\"\n\n    if\
-          \ phase_num == 1:\n        path_to_model = \"/input_model/model\"\n    \
-          \    path_to_data = \"/input_data/knowledge_processed_data/data.jsonl\"\n\
-          \    elif phase_num == 2:\n        path_to_model = list_phase1_final_model()\n\
-          \        path_to_data = \"/input_data/skills_processed_data/data.jsonl\"\
-          \n\n    image = \"quay.io/redhat-et/ilab:1.2\"\n\n    manifest = inspect.cleandoc(\n\
-          \        f\"\"\"\n        apiVersion: kubeflow.org/v1\n        kind: PyTorchJob\n\
-          \        metadata:\n          name: {name}\n        spec:\n          nprocPerNode:\
-          \ \\\\\"{nproc_per_node}\\\\\"\n          pytorchReplicaSpecs:\n       \
-          \     Master:\n              replicas: 1\n              restartPolicy: OnFailure\n\
-          \              template:\n                metadata:\n                  annotations:\n\
-          \                    sidecar.istio.io/inject: 'false'\n                spec:\n\
-          \                  containers:\n                    - args:\n          \
-          \              - |\n                          echo \"Running phase {phase_num}\"\
+          \ phase_num == 1:\n        path_to_model = \"/input_model\"\n        path_to_data\
+          \ = \"/input_data/knowledge/data.jsonl\"\n    elif phase_num == 2:\n   \
+          \     path_to_model = list_phase1_final_model()\n        path_to_data =\
+          \ \"/input_data/skills/data.jsonl\"\n    else:\n        raise RuntimeError(f\"\
+          Unsupported value of {phase_num=}\")\n\n    image = \"quay.io/redhat-et/ilab:1.2\"\
+          \n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
+          \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
+          \   name: {name}\n        spec:\n          nprocPerNode: \\\\\"{nproc_per_node}\\\
+          \\\"\n          pytorchReplicaSpecs:\n            Master:\n            \
+          \  replicas: 1\n              restartPolicy: OnFailure\n              template:\n\
+          \                metadata:\n                  annotations:\n           \
+          \         sidecar.istio.io/inject: 'false'\n                spec:\n    \
+          \              containers:\n                    - args:\n              \
+          \          - |\n                          echo \"Running phase {phase_num}\"\
           \n                          echo \"Using {path_to_model} model for training\"\
           \n                          echo \"Using {path_to_data} data for training\"\
           \n                          mkdir -p /output/phase_{phase_num}/model;\n\
@@ -1184,29 +1182,29 @@ deploymentSpec:
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef run_final_eval_op(\n    mmlu_branch_output: Output[Artifact],\n\
           \    mt_bench_branch_output: Output[Artifact],\n    base_model_dir: str,\n\
-          \    tasks: Input[Dataset],\n    taxonomy: Input[Dataset],\n    base_branch:\
-          \ str,\n    candidate_branch: str,\n    max_workers: str,\n    device: str,\n\
-          \    model_dtype: str,\n    few_shots: int,\n    batch_size: str,\n    merge_system_user_message:\
-          \ bool,\n    candidate_model: str = None,\n):\n    import json\n    import\
-          \ os\n    import subprocess\n\n    import torch\n    from instructlab.eval.mmlu\
-          \ import MMLU_TASKS, MMLUBranchEvaluator\n    from instructlab.eval.mt_bench\
-          \ import MTBenchBranchEvaluator\n    from instructlab.model.evaluate import\
-          \ qa_pairs_to_qna_to_avg_scores, sort_score\n\n    if judge_ca_cert := os.getenv(\"\
-          JUDGE_CA_CERT_PATH\"):\n        import httpx\n        import openai\n\n\
-          \        # Create a custom HTTP client\n        class CustomHttpClient(httpx.Client):\n\
-          \            def __init__(self, *args, **kwargs):\n                # Use\
-          \ the custom CA certificate\n                kwargs.setdefault(\"verify\"\
-          , judge_ca_cert)\n                super().__init__(*args, **kwargs)\n\n\
-          \        # Create a new OpenAI class that uses the custom HTTP client\n\
-          \        class CustomOpenAI(openai.OpenAI):\n            def __init__(self,\
-          \ *args, **kwargs):\n                custom_client = CustomHttpClient()\n\
-          \                super().__init__(http_client=custom_client, *args, **kwargs)\n\
-          \n        # Monkey patch the OpenAI class in the openai module, so that\
-          \ the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\n    print(\"\
-          Starting Final Eval...\")\n\n    def launch_vllm(\n        model_path: str,\
-          \ gpu_count: int, retries: int = 120, delay: int = 10\n    ) -> tuple:\n\
-          \        import subprocess\n        import sys\n        import time\n\n\
-          \        import requests\n        from instructlab.model.backends.common\
+          \    base_branch: str,\n    candidate_branch: str,\n    max_workers: str,\n\
+          \    device: str,\n    model_dtype: str,\n    few_shots: int,\n    batch_size:\
+          \ str,\n    merge_system_user_message: bool,\n    candidate_model: str =\
+          \ None,\n    taxonomy_path: str = \"/input/taxonomy\",\n    sdg_path: str\
+          \ = \"/input/sdg\",\n):\n    import json\n    import os\n    import subprocess\n\
+          \n    import torch\n    from instructlab.eval.mmlu import MMLU_TASKS, MMLUBranchEvaluator\n\
+          \    from instructlab.eval.mt_bench import MTBenchBranchEvaluator\n    from\
+          \ instructlab.model.evaluate import qa_pairs_to_qna_to_avg_scores, sort_score\n\
+          \n    if judge_ca_cert := os.getenv(\"JUDGE_CA_CERT_PATH\"):\n        import\
+          \ httpx\n        import openai\n\n        # Create a custom HTTP client\n\
+          \        class CustomHttpClient(httpx.Client):\n            def __init__(self,\
+          \ *args, **kwargs):\n                # Use the custom CA certificate\n \
+          \               kwargs.setdefault(\"verify\", judge_ca_cert)\n         \
+          \       super().__init__(*args, **kwargs)\n\n        # Create a new OpenAI\
+          \ class that uses the custom HTTP client\n        class CustomOpenAI(openai.OpenAI):\n\
+          \            def __init__(self, *args, **kwargs):\n                custom_client\
+          \ = CustomHttpClient()\n                super().__init__(http_client=custom_client,\
+          \ *args, **kwargs)\n\n        # Monkey patch the OpenAI class in the openai\
+          \ module, so that the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\
+          \n    print(\"Starting Final Eval...\")\n\n    def launch_vllm(\n      \
+          \  model_path: str, gpu_count: int, retries: int = 120, delay: int = 10\n\
+          \    ) -> tuple:\n        import subprocess\n        import sys\n      \
+          \  import time\n\n        import requests\n        from instructlab.model.backends.common\
           \ import free_tcp_ipv4_port\n\n        free_port = free_tcp_ipv4_port(\"\
           127.0.0.1\")\n        port = str(free_port)\n        vllm_server = f\"http://127.0.0.1:{port}/v1\"\
           \n\n        command = [\n            sys.executable,\n            \"-m\"\
@@ -1311,8 +1309,8 @@ deploymentSpec:
           \ update sdg repo: https://github.com/instructlab/sdg/blob/366814b3e89e28c98c0d2a276ad0759c567d2798/src/instructlab/sdg/eval_data.py#L84-%23L114\n\
           \        update_test_lines_in_files(base_dir)\n        return matching_dirs\n\
           \n    print(\"Starting MMLU_Branch...\")\n\n    mmlu_tasks = [\"mmlu_pr\"\
-          ]\n\n    node_dataset_dirs = find_node_dataset_directories(tasks.path)\n\
-          \n    # This assumes generated filesystem from ilab sdg, which\n    # generates\
+          ]\n\n    node_dataset_dirs = find_node_dataset_directories(sdg_path)\n\n\
+          \    # This assumes generated filesystem from ilab sdg, which\n    # generates\
           \ a node_datasets_ directory for MMLU custom tasks data\n    if node_dataset_dirs:\n\
           \        tasks_dir = node_dataset_dirs[0]\n\n        mmlu_branch_evaluators\
           \ = [\n            MMLUBranchEvaluator(\n                model_path=candidate_model,\n\
@@ -1363,10 +1361,10 @@ deploymentSpec:
           \    #\n    # With instructlab, model_name is synonomous with model_path\n\
           \    mt_bench_evaluators = [\n        MTBenchBranchEvaluator(\n        \
           \    model_name=candidate_model,\n            judge_model_name=judge_model_name,\n\
-          \            taxonomy_git_repo_path=taxonomy.path,\n            branch=candidate_branch,\n\
+          \            taxonomy_git_repo_path=taxonomy_path,\n            branch=candidate_branch,\n\
           \            output_dir=output_dir,\n            merge_system_user_message=merge_system_user_message,\n\
           \        ),\n        MTBenchBranchEvaluator(\n            model_name=base_model_dir,\n\
-          \            judge_model_name=judge_model_name,\n            taxonomy_git_repo_path=taxonomy.path,\n\
+          \            judge_model_name=judge_model_name,\n            taxonomy_git_repo_path=taxonomy_path,\n\
           \            branch=base_branch,\n            output_dir=output_dir,\n \
           \           merge_system_user_message=merge_system_user_message,\n     \
           \   ),\n    ]\n\n    # ilab/evaluate uses a magic word for its mt_bench\
@@ -1589,10 +1587,10 @@ deploymentSpec:
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef sdg_op(\n    num_instructions_to_generate: int,\n    pipeline:\
-          \ str,\n    taxonomy: dsl.Input[dsl.Dataset],\n    sdg: dsl.Output[dsl.Dataset],\n\
-          \    repo_branch: Optional[str],\n    repo_pr: Optional[int],\n):\n    from\
-          \ os import getenv, path\n\n    import openai\n    import yaml\n    from\
-          \ instructlab.sdg import generate_data\n    from instructlab.sdg.utils.taxonomy\
+          \ str,\n    repo_branch: Optional[str],\n    repo_pr: Optional[int],\n \
+          \   taxonomy_path: str = \"/data/taxonomy\",\n    sdg_path: str = \"/data/sdg\"\
+          ,\n):\n    from os import getenv, path\n\n    import openai\n    import\
+          \ yaml\n    from instructlab.sdg import generate_data\n    from instructlab.sdg.utils.taxonomy\
           \ import read_taxonomy\n\n    SAMPLING_SIZE = 70\n\n    def set_precomputed_skills_data_ratio(sampling_size):\n\
           \        skills_recipe = \"/usr/share/instructlab/sdg/default_data_recipes/skills.yaml\"\
           \n        if path.exists(skills_recipe):\n            with open(skills_recipe,\
@@ -1604,17 +1602,41 @@ deploymentSpec:
           )\n    client = openai.OpenAI(base_url=endpoint, api_key=api_key)\n\n  \
           \  taxonomy_base = \"main\" if repo_branch or (repo_pr and int(repo_pr)\
           \ > 0) else \"empty\"\n\n    print(\"Generating synthetic dataset for:\"\
-          )\n    print()\n    print(read_taxonomy(taxonomy.path, taxonomy_base))\n\
+          )\n    print()\n    print(read_taxonomy(taxonomy_path, taxonomy_base))\n\
           \n    # Temporary measure to limit the amount of precomputed skills data\
           \ used to construct the SDG dataset.\n    # Need during development to decrease\
           \ training loop times and the cost of model quality.\n    set_precomputed_skills_data_ratio(sampling_size=SAMPLING_SIZE)\n\
           \n    # generate_data has a magic word for its taxonomy_base argument -\
           \ 'empty'\n    # it allows generating from the whole repo, see:\n    # https://github.com/instructlab/sdg/blob/c6a9e74a1618b1077cd38e713b8aaed8b7c0c8ce/src/instructlab/sdg/utils/taxonomy.py#L230\n\
           \    generate_data(\n        client=client,\n        num_instructions_to_generate=num_instructions_to_generate,\n\
-          \        output_dir=sdg.path,\n        taxonomy=taxonomy.path,\n       \
+          \        output_dir=sdg_path,\n        taxonomy=taxonomy_path,\n       \
           \ taxonomy_base=taxonomy_base,\n        model_name=model,\n        pipeline=pipeline,\n\
           \        chunk_word_count=1000,\n        server_ctx_size=4096,\n    )\n\n"
         image: quay.io/redhat-et/ilab:1.2
+    exec-sdg-to-artifact-op:
+      container:
+        args:
+        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['sdg'].path}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
+    exec-skills-processed-data-to-artifact-op:
+      container:
+        args:
+        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['skills_processed_data'].path}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
+    exec-taxonomy-to-artifact-op:
+      container:
+        args:
+        - cp -r {{$.inputs.parameters['pvc_path']}} {{$.outputs.artifacts['taxonomy'].path}}
+        command:
+        - /bin/sh
+        - -c
+        image: registry.access.redhat.com/ubi9/toolbox
 pipelineInfo:
   description: InstructLab pipeline
   displayName: InstructLab
@@ -1622,68 +1644,6 @@ pipelineInfo:
 root:
   dag:
     tasks:
-      artifact-to-pvc-op:
-        cachingOptions: {}
-        componentRef:
-          name: comp-artifact-to-pvc-op
-        dependentTasks:
-        - createpvc
-        - huggingface-importer-op
-        inputs:
-          artifacts:
-            data:
-              taskOutputArtifact:
-                outputArtifactKey: model
-                producerTask: huggingface-importer-op
-          parameters:
-            pvc_path:
-              runtimeValue:
-                constant: /model
-        retryPolicy:
-          backoffDuration: 0s
-          backoffFactor: 2.0
-          backoffMaxDuration: 3600s
-          maxRetryCount: 3
-        taskInfo:
-          name: artifact-to-pvc-op
-      artifact-to-pvc-op-2:
-        cachingOptions: {}
-        componentRef:
-          name: comp-artifact-to-pvc-op-2
-        dependentTasks:
-        - createpvc-2
-        - data-processing-op
-        inputs:
-          artifacts:
-            data:
-              taskOutputArtifact:
-                outputArtifactKey: skills_processed_data
-                producerTask: data-processing-op
-          parameters:
-            pvc_path:
-              runtimeValue:
-                constant: /data
-        taskInfo:
-          name: artifact-to-pvc-op-2
-      artifact-to-pvc-op-3:
-        cachingOptions: {}
-        componentRef:
-          name: comp-artifact-to-pvc-op-3
-        dependentTasks:
-        - createpvc-2
-        - data-processing-op
-        inputs:
-          artifacts:
-            data:
-              taskOutputArtifact:
-                outputArtifactKey: knowledge_processed_data
-                producerTask: data-processing-op
-          parameters:
-            pvc_path:
-              runtimeValue:
-                constant: /data
-        taskInfo:
-          name: artifact-to-pvc-op-3
       createpvc:
         cachingOptions:
           enableCache: true
@@ -1697,10 +1657,10 @@ root:
                 - ReadWriteMany
             pvc_name_suffix:
               runtimeValue:
-                constant: -model-cache
+                constant: -sdg
             size:
               runtimeValue:
-                constant: 100Gi
+                constant: 1Gi
             storage_class_name:
               componentInputParameter: storage_class_name
         taskInfo:
@@ -1718,10 +1678,10 @@ root:
                 - ReadWriteMany
             pvc_name_suffix:
               runtimeValue:
-                constant: -sdg
+                constant: -model-cache
             size:
               runtimeValue:
-                constant: 1Gi
+                constant: 100Gi
             storage_class_name:
               componentInputParameter: storage_class_name
         taskInfo:
@@ -1748,23 +1708,14 @@ root:
         taskInfo:
           name: createpvc-3
       data-processing-op:
-        cachingOptions:
-          enableCache: true
+        cachingOptions: {}
         componentRef:
           name: comp-data-processing-op
         dependentTasks:
+        - createpvc
+        - createpvc-2
         - huggingface-importer-op
         - sdg-op
-        inputs:
-          artifacts:
-            model:
-              taskOutputArtifact:
-                outputArtifactKey: model
-                producerTask: huggingface-importer-op
-            sdg:
-              taskOutputArtifact:
-                outputArtifactKey: sdg
-                producerTask: sdg-op
         taskInfo:
           name: data-processing-op
       deletepvc:
@@ -1790,23 +1741,6 @@ root:
         componentRef:
           name: comp-deletepvc-2
         dependentTasks:
-        - createpvc-2
-        - pvc-to-artifact-op
-        - pvc-to-model-op
-        inputs:
-          parameters:
-            pvc_name:
-              taskOutputParameter:
-                outputParameterKey: name
-                producerTask: createpvc-2
-        taskInfo:
-          name: deletepvc-2
-      deletepvc-3:
-        cachingOptions:
-          enableCache: true
-        componentRef:
-          name: comp-deletepvc-3
-        dependentTasks:
         - createpvc
         - pvc-to-artifact-op
         - pvc-to-model-op
@@ -1817,12 +1751,30 @@ root:
                 outputParameterKey: name
                 producerTask: createpvc
         taskInfo:
-          name: deletepvc-3
-      git-clone-op:
+          name: deletepvc-2
+      deletepvc-3:
         cachingOptions:
           enableCache: true
         componentRef:
+          name: comp-deletepvc-3
+        dependentTasks:
+        - createpvc-2
+        - pvc-to-artifact-op
+        - pvc-to-model-op
+        inputs:
+          parameters:
+            pvc_name:
+              taskOutputParameter:
+                outputParameterKey: name
+                producerTask: createpvc-2
+        taskInfo:
+          name: deletepvc-3
+      git-clone-op:
+        cachingOptions: {}
+        componentRef:
           name: comp-git-clone-op
+        dependentTasks:
+        - createpvc
         inputs:
           parameters:
             repo_branch:
@@ -1834,23 +1786,33 @@ root:
         taskInfo:
           name: git-clone-op
       huggingface-importer-op:
-        cachingOptions:
-          enableCache: true
+        cachingOptions: {}
         componentRef:
           name: comp-huggingface-importer-op
+        dependentTasks:
+        - createpvc-2
         inputs:
           parameters:
             repo_name:
               componentInputParameter: base_model
         taskInfo:
           name: huggingface-importer-op
+      knowledge-processed-data-to-artifact-op:
+        cachingOptions: {}
+        componentRef:
+          name: comp-knowledge-processed-data-to-artifact-op
+        dependentTasks:
+        - createpvc
+        - data-processing-op
+        taskInfo:
+          name: knowledge-processed-data-to-artifact-op
       kubectl-apply-op:
         cachingOptions: {}
         componentRef:
           name: comp-kubectl-apply-op
         dependentTasks:
-        - artifact-to-pvc-op
-        - artifact-to-pvc-op-3
+        - data-processing-op
+        - huggingface-importer-op
         - pytorchjob-manifest-op
         inputs:
           parameters:
@@ -1865,8 +1827,6 @@ root:
         componentRef:
           name: comp-kubectl-apply-op-2
         dependentTasks:
-        - artifact-to-pvc-op
-        - artifact-to-pvc-op-3
         - pytorchjob-manifest-op-2
         inputs:
           parameters:
@@ -1976,7 +1936,7 @@ root:
             input_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
-                producerTask: createpvc-2
+                producerTask: createpvc
             learning_rate:
               componentInputParameter: learning_rate
             max_batch_len:
@@ -1984,11 +1944,11 @@ root:
             model_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
-                producerTask: createpvc
+                producerTask: createpvc-2
             name_suffix:
               taskOutputParameter:
                 outputParameterKey: name
-                producerTask: createpvc-2
+                producerTask: createpvc
             nnodes:
               componentInputParameter: nnodes
             nproc_per_node:
@@ -2026,7 +1986,7 @@ root:
             input_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
-                producerTask: createpvc-2
+                producerTask: createpvc
             learning_rate:
               componentInputParameter: learning_rate
             max_batch_len:
@@ -2034,11 +1994,11 @@ root:
             model_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
-                producerTask: createpvc
+                producerTask: createpvc-2
             name_suffix:
               taskOutputParameter:
                 outputParameterKey: name
-                producerTask: createpvc-2
+                producerTask: createpvc
             nnodes:
               componentInputParameter: nnodes
             nproc_per_node:
@@ -2068,19 +2028,8 @@ root:
         dependentTasks:
         - createpvc
         - createpvc-3
-        - git-clone-op
         - run-mt-bench-op
-        - sdg-op
         inputs:
-          artifacts:
-            tasks:
-              taskOutputArtifact:
-                outputArtifactKey: sdg
-                producerTask: sdg-op
-            taxonomy:
-              taskOutputArtifact:
-                outputArtifactKey: taxonomy
-                producerTask: git-clone-op
           parameters:
             base_branch:
               componentInputParameter: repo_branch
@@ -2131,18 +2080,13 @@ root:
         taskInfo:
           name: run-mt-bench-op
       sdg-op:
-        cachingOptions:
-          enableCache: true
+        cachingOptions: {}
         componentRef:
           name: comp-sdg-op
         dependentTasks:
+        - createpvc
         - git-clone-op
         inputs:
-          artifacts:
-            taxonomy:
-              taskOutputArtifact:
-                outputArtifactKey: taxonomy
-                producerTask: git-clone-op
           parameters:
             num_instructions_to_generate:
               componentInputParameter: num_instructions_to_generate
@@ -2154,6 +2098,37 @@ root:
               componentInputParameter: repo_pr
         taskInfo:
           name: sdg-op
+      sdg-to-artifact-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-sdg-to-artifact-op
+        dependentTasks:
+        - createpvc
+        - git-clone-op
+        - sdg-op
+        taskInfo:
+          name: sdg-to-artifact-op
+      skills-processed-data-to-artifact-op:
+        cachingOptions: {}
+        componentRef:
+          name: comp-skills-processed-data-to-artifact-op
+        dependentTasks:
+        - createpvc
+        - data-processing-op
+        taskInfo:
+          name: skills-processed-data-to-artifact-op
+      taxonomy-to-artifact-op:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-taxonomy-to-artifact-op
+        dependentTasks:
+        - createpvc
+        - git-clone-op
+        - sdg-op
+        taskInfo:
+          name: taxonomy-to-artifact-op
   inputDefinitions:
     parameters:
       base_model:
@@ -2252,24 +2227,34 @@ platforms:
   kubernetes:
     deploymentSpec:
       executors:
-        exec-artifact-to-pvc-op:
+        exec-data-processing-op:
           pvcMount:
           - mountPath: /model
             taskOutputParameter:
               outputParameterKey: name
+              producerTask: createpvc-2
+          - mountPath: /data
+            taskOutputParameter:
+              outputParameterKey: name
               producerTask: createpvc
-        exec-artifact-to-pvc-op-2:
+        exec-git-clone-op:
           pvcMount:
           - mountPath: /data
             taskOutputParameter:
               outputParameterKey: name
+              producerTask: createpvc
+        exec-huggingface-importer-op:
+          pvcMount:
+          - mountPath: /model
+            taskOutputParameter:
+              outputParameterKey: name
               producerTask: createpvc-2
-        exec-artifact-to-pvc-op-3:
+        exec-knowledge-processed-data-to-artifact-op:
           pvcMount:
           - mountPath: /data
             taskOutputParameter:
               outputParameterKey: name
-              producerTask: createpvc-2
+              producerTask: createpvc
         exec-list-models-in-directory-op:
           pvcMount:
           - mountPath: /output
@@ -2309,6 +2294,10 @@ platforms:
             taskOutputParameter:
               outputParameterKey: name
               producerTask: createpvc-3
+          - mountPath: /input
+            taskOutputParameter:
+              outputParameterKey: name
+              producerTask: createpvc
           - mountPath: /data
             taskOutputParameter:
               outputParameterKey: name
@@ -2348,8 +2337,31 @@ platforms:
               envVar: model
           imagePullSecret:
           - secretName: redhat-et-ilab-botty-pull-secret
+          pvcMount:
+          - mountPath: /data
+            taskOutputParameter:
+              outputParameterKey: name
+              producerTask: createpvc
           secretAsEnv:
           - keyToEnv:
             - envVar: api_key
               secretKey: api_key
             secretName: kfp-model-server
+        exec-sdg-to-artifact-op:
+          pvcMount:
+          - mountPath: /data
+            taskOutputParameter:
+              outputParameterKey: name
+              producerTask: createpvc
+        exec-skills-processed-data-to-artifact-op:
+          pvcMount:
+          - mountPath: /data
+            taskOutputParameter:
+              outputParameterKey: name
+              producerTask: createpvc
+        exec-taxonomy-to-artifact-op:
+          pvcMount:
+          - mountPath: /data
+            taskOutputParameter:
+              outputParameterKey: name
+              producerTask: createpvc

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -543,7 +543,7 @@ components:
         models_path_prefix:
           parameterType: STRING
         output_path:
-          defaultValue: /output
+          defaultValue: /output/mt_bench_data.json
           isOptional: true
           parameterType: STRING
     outputDefinitions:
@@ -1448,42 +1448,43 @@ deploymentSpec:
           \ bool,\n    # generate_answers,judgment uses a magic word for its mt_bench\
           \ evaluator  - 'auto'\n    # with 'auto', number of gpus allocated for serving\
           \ is calculated based on environment\n    # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36\n\
-          \    max_workers: str,\n    output_path: str = \"/output\",\n    models_list:\
-          \ List[str] = None,\n    models_folder: Optional[str] = None,\n    device:\
-          \ str = None,\n    best_score_file: Optional[str] = None,\n) -> NamedTuple(\"\
-          outputs\", best_model=str, best_score=float):\n    import json\n    import\
-          \ os\n    import subprocess\n\n    import torch\n    from instructlab.eval.mt_bench\
-          \ import MTBenchEvaluator\n\n    if judge_ca_cert := os.getenv(\"JUDGE_CA_CERT_PATH\"\
-          ):\n        import httpx\n        import openai\n\n        # Create a custom\
-          \ HTTP client\n        class CustomHttpClient(httpx.Client):\n         \
-          \   def __init__(self, *args, **kwargs):\n                # Use the custom\
-          \ CA certificate\n                kwargs.setdefault(\"verify\", judge_ca_cert)\n\
-          \                super().__init__(*args, **kwargs)\n\n        # Create a\
-          \ new OpenAI class that uses the custom HTTP client\n        class CustomOpenAI(openai.OpenAI):\n\
-          \            def __init__(self, *args, **kwargs):\n                custom_client\
-          \ = CustomHttpClient()\n                super().__init__(http_client=custom_client,\
-          \ *args, **kwargs)\n\n        # Monkey patch the OpenAI class in the openai\
-          \ module, so that the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\
-          \n    def launch_vllm(\n        model_path: str, gpu_count: int, retries:\
-          \ int = 120, delay: int = 10\n    ) -> tuple:\n        import subprocess\n\
-          \        import sys\n        import time\n\n        import requests\n  \
-          \      from instructlab.model.backends.common import free_tcp_ipv4_port\n\
-          \n        free_port = free_tcp_ipv4_port(\"127.0.0.1\")\n        port =\
-          \ str(free_port)\n        vllm_server = f\"http://127.0.0.1:{port}/v1\"\n\
-          \n        command = [\n            sys.executable,\n            \"-m\",\n\
-          \            \"vllm.entrypoints.openai.api_server\",\n            \"--port\"\
-          ,\n            port,\n            \"--model\",\n            model_path,\n\
-          \        ]\n        if gpu_count > 0:\n            command += [\n      \
-          \          \"--tensor-parallel-size\",\n                str(gpu_count),\n\
-          \            ]\n\n        process = subprocess.Popen(args=command)\n\n \
-          \       print(f\"Waiting for vLLM server to start at {vllm_server}...\"\
-          )\n\n        for attempt in range(retries):\n            try:\n        \
-          \        response = requests.get(f\"{vllm_server}/models\")\n          \
-          \      if response.status_code == 200:\n                    print(f\"vLLM\
-          \ server is up and running at {vllm_server}.\")\n                    return\
-          \ process, vllm_server\n            except requests.ConnectionError:\n \
-          \               pass\n\n            print(\n                f\"Server not\
-          \ available yet, retrying in {delay} seconds (Attempt {attempt + 1}/{retries})...\"\
+          \    max_workers: str,\n    output_path: str = \"/output/mt_bench_data.json\"\
+          ,\n    models_list: List[str] = None,\n    models_folder: Optional[str]\
+          \ = None,\n    device: str = None,\n    best_score_file: Optional[str] =\
+          \ None,\n) -> NamedTuple(\"outputs\", best_model=str, best_score=float):\n\
+          \    import json\n    import os\n    import subprocess\n\n    import torch\n\
+          \    from instructlab.eval.mt_bench import MTBenchEvaluator\n\n    if judge_ca_cert\
+          \ := os.getenv(\"JUDGE_CA_CERT_PATH\"):\n        import httpx\n        import\
+          \ openai\n\n        # Create a custom HTTP client\n        class CustomHttpClient(httpx.Client):\n\
+          \            def __init__(self, *args, **kwargs):\n                # Use\
+          \ the custom CA certificate\n                kwargs.setdefault(\"verify\"\
+          , judge_ca_cert)\n                super().__init__(*args, **kwargs)\n\n\
+          \        # Create a new OpenAI class that uses the custom HTTP client\n\
+          \        class CustomOpenAI(openai.OpenAI):\n            def __init__(self,\
+          \ *args, **kwargs):\n                custom_client = CustomHttpClient()\n\
+          \                super().__init__(http_client=custom_client, *args, **kwargs)\n\
+          \n        # Monkey patch the OpenAI class in the openai module, so that\
+          \ the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\n    def\
+          \ launch_vllm(\n        model_path: str, gpu_count: int, retries: int =\
+          \ 120, delay: int = 10\n    ) -> tuple:\n        import subprocess\n   \
+          \     import sys\n        import time\n\n        import requests\n     \
+          \   from instructlab.model.backends.common import free_tcp_ipv4_port\n\n\
+          \        free_port = free_tcp_ipv4_port(\"127.0.0.1\")\n        port = str(free_port)\n\
+          \        vllm_server = f\"http://127.0.0.1:{port}/v1\"\n\n        command\
+          \ = [\n            sys.executable,\n            \"-m\",\n            \"\
+          vllm.entrypoints.openai.api_server\",\n            \"--port\",\n       \
+          \     port,\n            \"--model\",\n            model_path,\n       \
+          \ ]\n        if gpu_count > 0:\n            command += [\n             \
+          \   \"--tensor-parallel-size\",\n                str(gpu_count),\n     \
+          \       ]\n\n        process = subprocess.Popen(args=command)\n\n      \
+          \  print(f\"Waiting for vLLM server to start at {vllm_server}...\")\n\n\
+          \        for attempt in range(retries):\n            try:\n            \
+          \    response = requests.get(f\"{vllm_server}/models\")\n              \
+          \  if response.status_code == 200:\n                    print(f\"vLLM server\
+          \ is up and running at {vllm_server}.\")\n                    return process,\
+          \ vllm_server\n            except requests.ConnectionError:\n          \
+          \      pass\n\n            print(\n                f\"Server not available\
+          \ yet, retrying in {delay} seconds (Attempt {attempt + 1}/{retries})...\"\
           \n            )\n            time.sleep(delay)\n\n        raise RuntimeError(\n\
           \            f\"Failed to start vLLM server at {vllm_server} after {retries}\
           \ retries.\"\n        )\n\n    def shutdown_vllm(process: subprocess.Popen,\
@@ -1539,15 +1540,15 @@ deploymentSpec:
           : overall_score,\n            \"turn_scores\": turn_scores,\n          \
           \  \"qa_scores\": qa_pairs,\n            \"error_rate\": error_rate,\n \
           \       }\n\n        all_mt_bench_data.append(mt_bench_data)\n        scores[model_path]\
-          \ = overall_score\n\n    with open(f\"{output_path}/mt_bench_data.json\"\
-          , \"w\", encoding=\"utf-8\") as f:\n        json.dump(all_mt_bench_data,\
-          \ f, indent=4)\n\n    outputs = NamedTuple(\"outputs\", best_model=str,\
-          \ best_score=float)\n    best_model = max(scores, key=scores.get)\n    best_score\
-          \ = scores[best_model]\n    if best_score_file:\n        with open(best_score_file,\
-          \ \"w\", encoding=\"utf-8\") as f:\n            json.dump({\"best_model\"\
-          : best_model, \"best_score\": best_score}, f, indent=4)\n\n    # Rename\
-          \ the best model directory to \"candidate_model\" for the next step\n  \
-          \  # So we know which model to use for the final evaluation\n    if os.path.exists(os.path.join(models_path_prefix,\
+          \ = overall_score\n\n    with open(output_path, \"w\", encoding=\"utf-8\"\
+          ) as f:\n        json.dump(all_mt_bench_data, f, indent=4)\n\n    outputs\
+          \ = NamedTuple(\"outputs\", best_model=str, best_score=float)\n    best_model\
+          \ = max(scores, key=scores.get)\n    best_score = scores[best_model]\n \
+          \   if best_score_file:\n        with open(best_score_file, \"w\", encoding=\"\
+          utf-8\") as f:\n            json.dump({\"best_model\": best_model, \"best_score\"\
+          : best_score}, f, indent=4)\n\n    # Rename the best model directory to\
+          \ \"candidate_model\" for the next step\n    # So we know which model to\
+          \ use for the final evaluation\n    if os.path.exists(os.path.join(models_path_prefix,\
           \ \"candidate_model\")):\n        print(\"candidate_model already exists.\
           \ Skipping renaming\")\n    else:\n        os.rename(\n            os.path.join(models_path_prefix,\
           \ best_model),\n            os.path.join(models_path_prefix, \"candidate_model\"\
@@ -1658,7 +1659,7 @@ root:
                 constant: -sdg
             size:
               runtimeValue:
-                constant: 1Gi
+                constant: 10Gi
             storage_class_name:
               componentInputParameter: storage_class_name
         taskInfo:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1348,7 +1348,7 @@ deploymentSpec:
           \     }\n\n        with open(mmlu_branch_output.path, \"w\") as f:\n   \
           \         json.dump(mmlu_branch_data, f, indent=4)\n    else:\n        print(\"\
           No MMLU tasks directories found, skipping MMLU_branch evaluation.\")\n\n\
-          \    # MT_BENCH_BRANCH\n\n    print(\"Strating MT_BENCH_BRANCH ...\")\n\n\
+          \    # MT_BENCH_BRANCH\n\n    print(\"Starting MT_BENCH_BRANCH ...\")\n\n\
           \    judge_api_key = os.getenv(\"JUDGE_API_KEY\", \"\")\n    judge_model_name\
           \ = os.getenv(\"JUDGE_NAME\")\n    judge_endpoint = os.getenv(\"JUDGE_ENDPOINT\"\
           )\n\n    output_dir = \"/tmp/eval_output\"\n\n    # TODO: candidate_branch\
@@ -2036,7 +2036,7 @@ root:
               componentInputParameter: repo_branch
             base_model_dir:
               runtimeValue:
-                constant: /model
+                constant: /model/
             batch_size:
               componentInputParameter: batch_size
             candidate_branch:

--- a/sdg/__init__.py
+++ b/sdg/__init__.py
@@ -1,4 +1,15 @@
 from . import faked
-from .components import git_clone_op, sdg_op
+from .components import (
+    git_clone_op,
+    sdg_op,
+    sdg_to_artifact_op,
+    taxonomy_to_artifact_op,
+)
 
-__all__ = ["git_clone_op", "sdg_op", "faked"]
+__all__ = [
+    "git_clone_op",
+    "sdg_op",
+    "taxonomy_to_artifact_op",
+    "sdg_to_artifact_op",
+    "faked",
+]

--- a/sdg/faked/__init__.py
+++ b/sdg/faked/__init__.py
@@ -1,3 +1,8 @@
-from .components import git_clone_op, sdg_op
+from .components import (
+    git_clone_op,
+    sdg_op,
+    sdg_to_artifact_op,
+    taxonomy_to_artifact_op,
+)
 
-__all__ = ["git_clone_op", "sdg_op"]
+__all__ = ["git_clone_op", "sdg_op", "taxonomy_to_artifact_op", "sdg_to_artifact_op"]

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -1507,12 +1507,12 @@ from typing import *
 
 def run_mt_bench_op(
     models_path_prefix: str,
-    mt_bench_output: str,
     merge_system_user_message: bool,
     # generate_answers,judgment uses a magic word for its mt_bench evaluator  - 'auto'
     # with 'auto', number of gpus allocated for serving is calculated based on environment
     # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36
     max_workers: str,
+    output_path: str = "/output",
     models_list: List[str] = None,
     models_folder: Optional[str] = None,
     device: str = None,
@@ -1700,7 +1700,7 @@ def run_mt_bench_op(
         all_mt_bench_data.append(mt_bench_data)
         scores[model_path] = overall_score
 
-    with open(mt_bench_output, "w", encoding="utf-8") as f:
+    with open(f"{output_path}/mt_bench_data.json", "w", encoding="utf-8") as f:
         json.dump(all_mt_bench_data, f, indent=4)
 
     outputs = NamedTuple("outputs", best_model=str, best_score=float)

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -1081,16 +1081,30 @@ from typing import *
 def sdg_op(
     num_instructions_to_generate: int,
     pipeline: str,
-    taxonomy: str,
-    sdg: str,
     repo_branch: Optional[str],
     repo_pr: Optional[int],
+    taxonomy_path: str = "/data/taxonomy",
+    sdg_path: str = "/data/sdg",
 ):
-    from os import getenv
+    from os import getenv, path
 
     import openai
+    import yaml
     from instructlab.sdg import generate_data
     from instructlab.sdg.utils.taxonomy import read_taxonomy
+
+    SAMPLING_SIZE = 70
+
+    def set_precomputed_skills_data_ratio(sampling_size):
+        skills_recipe = "/usr/share/instructlab/sdg/default_data_recipes/skills.yaml"
+        if path.exists(skills_recipe):
+            with open(skills_recipe, "r") as file:
+                skills_yaml = yaml.load(file, Loader=yaml.Loader)
+
+            skills_yaml["datasets"][0]["sampling_size"] = sampling_size
+
+            with open(skills_recipe, "w", encoding="utf-8") as file:
+                yaml.dump(skills_yaml, file)
 
     api_key = getenv("api_key")
     model = getenv("model")
@@ -1101,7 +1115,11 @@ def sdg_op(
 
     print("Generating synthetic dataset for:")
     print()
-    print(read_taxonomy(taxonomy, taxonomy_base))
+    print(read_taxonomy(taxonomy_path, taxonomy_base))
+
+    # Temporary measure to limit the amount of precomputed skills data used to construct the SDG dataset.
+    # Need during development to decrease training loop times and the cost of model quality.
+    set_precomputed_skills_data_ratio(sampling_size=SAMPLING_SIZE)
 
     # generate_data has a magic word for its taxonomy_base argument - 'empty'
     # it allows generating from the whole repo, see:
@@ -1109,8 +1127,8 @@ def sdg_op(
     generate_data(
         client=client,
         num_instructions_to_generate=num_instructions_to_generate,
-        output_dir=sdg,
-        taxonomy=taxonomy,
+        output_dir=sdg_path,
+        taxonomy=taxonomy_path,
         taxonomy_base=taxonomy_base,
         model_name=model,
         pipeline=pipeline,
@@ -1119,7 +1137,7 @@ def sdg_op(
     )
 """
     exec_sdg_op_args = f"""
-sdg_op(num_instructions_to_generate={num_instructions_to_generate}, pipeline="{sdg_pipeline}", repo_branch="{exec_git_clone_op_repo_branch}", repo_pr={exec_git_clone_op_repo_pr}, taxonomy="{TAXONOMY_DATA_PATH}", sdg="{DATA_PVC_SDG_PATH}")
+sdg_op(num_instructions_to_generate={num_instructions_to_generate}, pipeline="{sdg_pipeline}", repo_branch="{exec_git_clone_op_repo_branch}", repo_pr={exec_git_clone_op_repo_pr}, taxonomy_path="{TAXONOMY_DATA_PATH}", sdg_path="{DATA_PVC_SDG_PATH}")
 """
 
     return kubernetes.client.V1Container(
@@ -1188,10 +1206,10 @@ def create_data_job(
 from typing import *
 
 def data_processing_op(
-    sdg: str,
-    skills_processed_data: str,
-    knowledge_processed_data: str,
-    model: str,
+    model_path: str = "/model",
+    sdg_path: str = "/data/sdg",
+    skills_path: str = "/data/skills",
+    knowledge_path: str = "/data/knowledge",
     max_seq_len: Optional[int] = 4096,
     max_batch_len: Optional[int] = 20000,
 ):
@@ -1206,9 +1224,9 @@ def data_processing_op(
     # define training-specific arguments
     skill_training_args = TrainingArgs(
         # define data-specific arguments
-        model_path=model,
-        data_path=f"{sdg}/skills_train_msgs*.jsonl",
-        data_output_dir=skills_processed_data,
+        model_path=model_path,
+        data_path=f"{sdg_path}/skills_train_msgs*.jsonl",
+        data_output_dir=skills_path,
         # define model-trianing parameters
         max_seq_len=max_seq_len,
         max_batch_len=max_batch_len,
@@ -1226,9 +1244,9 @@ def data_processing_op(
 
     knowledge_training_args = TrainingArgs(
         # define data-specific arguments
-        model_path=model,
-        data_path=f"{sdg}/knowledge_train_msgs*.jsonl",
-        data_output_dir=knowledge_processed_data,
+        model_path=model_path,
+        data_path=f"{sdg_path}/knowledge_train_msgs*.jsonl",
+        data_output_dir=knowledge_path,
         # define model-trianing parameters
         max_seq_len=max_seq_len,
         max_batch_len=max_batch_len,
@@ -1274,7 +1292,7 @@ def data_processing_op(
     data_processing(train_args=knowledge_training_args)
 """
     exec_data_processing_op_args = f"""
-data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", skills_processed_data="{PREPROCESSED_DATA_SKILLS_PATH}", knowledge_processed_data="{PREPROCESSED_DATA_KNOWLEDGE_PATH}")
+data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg_path="{DATA_PVC_SDG_PATH}", model_path="{DATA_PVC_MODEL_PATH}", skills_path="{PREPROCESSED_DATA_SKILLS_PATH}", knowledge_path="{PREPROCESSED_DATA_KNOWLEDGE_PATH}")
 """
 
     data_container = kubernetes.client.V1Container(
@@ -1714,8 +1732,6 @@ def run_final_eval_op(
     mmlu_branch_output: str,
     mt_bench_branch_output: str,
     base_model_dir: str,
-    tasks: str,
-    taxonomy: str,
     base_branch: str,
     candidate_branch: str,
     max_workers: str,
@@ -1725,6 +1741,8 @@ def run_final_eval_op(
     batch_size: str,
     merge_system_user_message: bool,
     candidate_model: str = None,
+    taxonomy_path: str = "/input/taxonomy",
+    sdg_path: str = "/input/sdg",
 ):
     import json
     import os
@@ -1972,7 +1990,7 @@ def run_final_eval_op(
 
     mmlu_tasks = ["mmlu_pr"]
 
-    node_dataset_dirs = find_node_dataset_directories(tasks)
+    node_dataset_dirs = find_node_dataset_directories(sdg_path)
 
     # This assumes generated filesystem from ilab sdg, which
     # generates a node_datasets_ directory for MMLU custom tasks data
@@ -2073,7 +2091,7 @@ def run_final_eval_op(
         MTBenchBranchEvaluator(
             model_name=candidate_model,
             judge_model_name=judge_model_name,
-            taxonomy_git_repo_path=taxonomy,
+            taxonomy_git_repo_path=taxonomy_path,
             branch=candidate_branch,
             output_dir=output_dir,
             merge_system_user_message=merge_system_user_message,
@@ -2081,7 +2099,7 @@ def run_final_eval_op(
         MTBenchBranchEvaluator(
             model_name=base_model_dir,
             judge_model_name=judge_model_name,
-            taxonomy_git_repo_path=taxonomy,
+            taxonomy_git_repo_path=taxonomy_path,
             branch=base_branch,
             output_dir=output_dir,
             merge_system_user_message=merge_system_user_message,
@@ -2188,7 +2206,7 @@ def run_final_eval_op(
         json.dump(mt_bench_branch_data, f, indent=4)
 """
     exec_run_final_eval_op_args = f"""
-run_final_eval_op(mmlu_branch_output="{MMLU_BRANCH_SCORES_PATH}", mt_bench_branch_output="{MT_BENCH_BRANCH_SCORES_PATH}", candidate_model="{CANDIDATE_MODEL_PATH}", taxonomy="{TAXONOMY_PATH}", tasks="{DATA_PVC_SDG_PATH}", base_branch="", candidate_branch="", device=None, base_model_dir="{DATA_PVC_MODEL_PATH}", max_workers="{MAX_WORKERS}", merge_system_user_message={MERGE_SYSTEM_USER_MESSAGE}, model_dtype="{MODEL_DTYPE}", few_shots={FEW_SHOTS}, batch_size="{BATCH_SIZE}")
+run_final_eval_op(mmlu_branch_output="{MMLU_BRANCH_SCORES_PATH}", mt_bench_branch_output="{MT_BENCH_BRANCH_SCORES_PATH}", candidate_model="{CANDIDATE_MODEL_PATH}", taxonomy_path="{TAXONOMY_PATH}", sdg_path="{DATA_PVC_SDG_PATH}", base_branch="", candidate_branch="", device=None, base_model_dir="{DATA_PVC_MODEL_PATH}", max_workers="{MAX_WORKERS}", merge_system_user_message={MERGE_SYSTEM_USER_MESSAGE}, model_dtype="{MODEL_DTYPE}", few_shots={FEW_SHOTS}, batch_size="{BATCH_SIZE}")
 """
 
     eval_container = kubernetes.client.V1Container(

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -1512,7 +1512,7 @@ def run_mt_bench_op(
     # with 'auto', number of gpus allocated for serving is calculated based on environment
     # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36
     max_workers: str,
-    output_path: str = "/output",
+    output_path: str = "/output/mt_bench_data.json",
     models_list: List[str] = None,
     models_folder: Optional[str] = None,
     device: str = None,
@@ -1700,7 +1700,7 @@ def run_mt_bench_op(
         all_mt_bench_data.append(mt_bench_data)
         scores[model_path] = overall_score
 
-    with open(f"{output_path}/mt_bench_data.json", "w", encoding="utf-8") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         json.dump(all_mt_bench_data, f, indent=4)
 
     outputs = NamedTuple("outputs", best_model=str, best_score=float)
@@ -1723,7 +1723,7 @@ def run_mt_bench_op(
     return outputs(best_model=best_model, best_score=best_score)
 """
     exec_run_mt_bench_op_args = f"""
-run_mt_bench_op(best_score_file="{MT_BENCH_SCORES_PATH}",mt_bench_output="{MT_BENCH_OUTPUT_PATH}",models_folder="{CANDIDATE_MODEL_PATH_PREFIX}",models_path_prefix="{CANDIDATE_MODEL_PATH_PREFIX}", max_workers="{MAX_WORKERS}", merge_system_user_message={MERGE_SYSTEM_USER_MESSAGE})
+run_mt_bench_op(best_score_file="{MT_BENCH_SCORES_PATH}",output_path="{MT_BENCH_OUTPUT_PATH}",models_folder="{CANDIDATE_MODEL_PATH_PREFIX}",models_path_prefix="{CANDIDATE_MODEL_PATH_PREFIX}", max_workers="{MAX_WORKERS}", merge_system_user_message={MERGE_SYSTEM_USER_MESSAGE})
 """
     exec_run_final_eval_op_command = """
 from typing import *

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -2069,7 +2069,7 @@ def run_final_eval_op(
 
     # MT_BENCH_BRANCH
 
-    print("Strating MT_BENCH_BRANCH ...")
+    print("Starting MT_BENCH_BRANCH ...")
 
     judge_api_key = os.getenv("JUDGE_API_KEY", "")
     judge_model_name = os.getenv("JUDGE_NAME")

--- a/standalone/standalone.tpl
+++ b/standalone/standalone.tpl
@@ -1148,7 +1148,7 @@ def create_data_job(
 {{exec_data_processing_op_command}}
 """
     exec_data_processing_op_args = f"""
-data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg="{DATA_PVC_SDG_PATH}", model="{DATA_PVC_MODEL_PATH}", skills_processed_data="{PREPROCESSED_DATA_SKILLS_PATH}", knowledge_processed_data="{PREPROCESSED_DATA_KNOWLEDGE_PATH}")
+data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg_path="{DATA_PVC_SDG_PATH}", model_path="{DATA_PVC_MODEL_PATH}", skills_path="{PREPROCESSED_DATA_SKILLS_PATH}", knowledge_path="{PREPROCESSED_DATA_KNOWLEDGE_PATH}")
 """
 
     data_container = kubernetes.client.V1Container(

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,4 +1,15 @@
 from . import faked
-from .components import data_processing_op, pytorchjob_manifest_op
+from .components import (
+    data_processing_op,
+    knowledge_processed_data_to_artifact_op,
+    pytorchjob_manifest_op,
+    skills_processed_data_to_artifact_op,
+)
 
-__all__ = ["data_processing_op", "pytorchjob_manifest_op", "faked"]
+__all__ = [
+    "data_processing_op",
+    "pytorchjob_manifest_op",
+    "skills_processed_data_to_artifact_op",
+    "knowledge_processed_data_to_artifact_op",
+    "faked",
+]

--- a/training/faked/__init__.py
+++ b/training/faked/__init__.py
@@ -1,3 +1,13 @@
-from .components import pytorchjob_manifest_op
+from .components import (
+    data_processing_op,
+    knowledge_processed_data_to_artifact_op,
+    pytorchjob_manifest_op,
+    skills_processed_data_to_artifact_op,
+)
 
-__all__ = ["pytorchjob_manifest_op"]
+__all__ = [
+    "data_processing_op",
+    "pytorchjob_manifest_op",
+    "skills_processed_data_to_artifact_op",
+    "knowledge_processed_data_to_artifact_op",
+]

--- a/training/faked/components.py
+++ b/training/faked/components.py
@@ -1,11 +1,11 @@
 # type: ignore
 # pylint: disable=import-outside-toplevel,missing-function-docstring,unused-argument
 
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 from kfp import dsl
 
-from utils.consts import PYTHON_IMAGE
+from utils.consts import PYTHON_IMAGE, TOOLBOX_IMAGE
 
 
 @dsl.component(base_image=PYTHON_IMAGE)
@@ -17,3 +17,39 @@ def pytorchjob_manifest_op(
 ) -> NamedTuple("outputs", manifest=str, name=str):
     Outputs = NamedTuple("outputs", manifest=str, name=str)
     return Outputs("", "")
+
+
+@dsl.component(base_image=PYTHON_IMAGE)
+def data_processing_op(
+    model_path: str = "/model",
+    sdg_path: str = "/data/sdg",
+    skills_path: str = "/data/skills",
+    knowledge_path: str = "/data/knowledge",
+    max_seq_len: Optional[int] = 4096,
+    max_batch_len: Optional[int] = 20000,
+):
+    return
+
+
+@dsl.container_component
+def skills_processed_data_to_artifact_op(
+    skills_processed_data: dsl.Output[dsl.Dataset],
+    pvc_path: str = "/data/skills",
+):
+    return dsl.ContainerSpec(
+        TOOLBOX_IMAGE,
+        ["/bin/sh", "-c"],
+        [f"cp -r {pvc_path} {skills_processed_data.path}"],
+    )
+
+
+@dsl.container_component
+def knowledge_processed_data_to_artifact_op(
+    knowledge_processed_data: dsl.Output[dsl.Dataset],
+    pvc_path: str = "/data/knowledge",
+):
+    return dsl.ContainerSpec(
+        TOOLBOX_IMAGE,
+        ["/bin/sh", "-c"],
+        [f"cp -r {pvc_path} {knowledge_processed_data.path}"],
+    )

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -4,15 +4,15 @@ from .components import (
     kubectl_apply_op,
     kubectl_wait_for_op,
     list_models_in_directory_op,
-    pvc_to_artifact_op,
     pvc_to_model_op,
+    pvc_to_mt_bench_op,
 )
 
 __all__ = [
     "kubectl_apply_op",
     "kubectl_wait_for_op",
     "huggingface_importer_op",
-    "pvc_to_artifact_op",
+    "pvc_to_mt_bench_op",
     "pvc_to_model_op",
     "list_models_in_directory_op",
     "faked",

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,6 +1,5 @@
 from . import faked
 from .components import (
-    artifact_to_pvc_op,
     huggingface_importer_op,
     kubectl_apply_op,
     kubectl_wait_for_op,
@@ -12,7 +11,6 @@ from .components import (
 __all__ = [
     "kubectl_apply_op",
     "kubectl_wait_for_op",
-    "artifact_to_pvc_op",
     "huggingface_importer_op",
     "pvc_to_artifact_op",
     "pvc_to_model_op",

--- a/utils/components.py
+++ b/utils/components.py
@@ -34,11 +34,11 @@ def kubectl_wait_for_op(
 
 
 @dsl.container_component
-def pvc_to_artifact_op(model: dsl.Output[dsl.Artifact], pvc_path: str):
+def pvc_to_mt_bench_op(mt_bench_output: dsl.Output[dsl.Artifact], pvc_path: str):
     return dsl.ContainerSpec(
         TOOLBOX_IMAGE,
         ["/bin/sh", "-c"],
-        [f"cp -r {pvc_path} {model.path}"],
+        [f"cp -r {pvc_path} {mt_bench_output.path}"],
     )
 
 
@@ -52,7 +52,7 @@ def pvc_to_model_op(model: dsl.Output[dsl.Model], pvc_path: str):
 
 
 @dsl.component
-def list_models_in_directory_op(models_folder: str) -> List:
+def list_models_in_directory_op(models_folder: str) -> List[str]:
     import os
 
     models = os.listdir(models_folder)

--- a/utils/components.py
+++ b/utils/components.py
@@ -34,15 +34,6 @@ def kubectl_wait_for_op(
 
 
 @dsl.container_component
-def artifact_to_pvc_op(data: dsl.Input[dsl.Artifact], pvc_path: str):
-    return dsl.ContainerSpec(
-        TOOLBOX_IMAGE,
-        ["/bin/sh", "-c"],
-        [f"cp -r {data.path} {pvc_path}"],
-    )
-
-
-@dsl.container_component
 def pvc_to_artifact_op(model: dsl.Output[dsl.Artifact], pvc_path: str):
     return dsl.ContainerSpec(
         TOOLBOX_IMAGE,
@@ -69,7 +60,7 @@ def list_models_in_directory_op(models_folder: str) -> List:
 
 
 @dsl.component(base_image=PYTHON_IMAGE, packages_to_install=["huggingface_hub"])
-def huggingface_importer_op(model: dsl.Output[dsl.Model], repo_name: str):
+def huggingface_importer_op(repo_name: str, model_path: str = "/model"):
     from huggingface_hub import snapshot_download
 
-    snapshot_download(repo_id=repo_name, cache_dir="/tmp", local_dir=model.path)
+    snapshot_download(repo_id=repo_name, cache_dir="/tmp", local_dir=model_path)

--- a/utils/faked/__init__.py
+++ b/utils/faked/__init__.py
@@ -1,13 +1,13 @@
 from .components import (
     kubectl_apply_op,
     kubectl_wait_for_op,
-    pvc_to_artifact_op,
     pvc_to_model_op,
+    pvc_to_mt_bench_op,
 )
 
 __all__ = [
     "kubectl_apply_op",
     "kubectl_wait_for_op",
-    "pvc_to_artifact_op",
+    "pvc_to_mt_bench_op",
     "pvc_to_model_op",
 ]

--- a/utils/faked/components.py
+++ b/utils/faked/components.py
@@ -21,7 +21,7 @@ def huggingface_importer_op(repo_name: str, model_path: str = "/model"):
 
 
 @dsl.component(base_image=PYTHON_IMAGE)
-def pvc_to_artifact_op(model: dsl.Output[dsl.Artifact], pvc_path: str):
+def pvc_to_mt_bench_op(mt_bench_output: dsl.Output[dsl.Artifact], pvc_path: str):
     return
 
 

--- a/utils/faked/components.py
+++ b/utils/faked/components.py
@@ -16,7 +16,7 @@ def kubectl_wait_for_op(condition: str, kind: str, name: str):
 
 
 @dsl.component(base_image=PYTHON_IMAGE)
-def huggingface_importer_op(model: dsl.Output[dsl.Model], repo_name: str):
+def huggingface_importer_op(repo_name: str, model_path: str = "/model"):
     return
 
 


### PR DESCRIPTION
**This PR is a draft and needs to be tested**

This PR touches a lot of things, be warned.

It transforms our current exec logic:

```mermaid
gantt
    title Before PR
    dateFormat m
    axisFormat %M
    tickInterval 1minute
    section Pod 1
    Do work:a1 , 00, 1m
    Upload output artifacts:a2, after a1, 1m
    section Pod 2
    Download input artifacts:a3, after a2, 1m
    Do work:a4, after a3, 1m
    Upload output artifacts:a5, after a4, 1m
```

To following:

```mermaid
gantt
    title After PR
    dateFormat m
    axisFormat %M
    tickInterval 1minute
    section Pod 1
    Do work:a1 , 00, 1m
    section Pod 2
    Do work:a4, after a1, 1m
    section Pod 3
    Upload output artifacts from Pod 2:a2, after a4, 1m
    section Pod 4
    Upload output artifacts from Pod 1:a5, after a1, 1m
```

It does so by replacing removing the need to upload output artifacts created by a previous task and subsequently downloading them when starting the current task. Instead it passes the data on PVC which is simply remounted to the pod of the task which needs those outputs.

This PR makes the pipeline to use following set of PVCs:

- Model PVC - stores LLM dowloaded from HF
- SDG PVC - stores taxonomy and SDG data, including preprocessed data
- Output PVC - stores newly trained models

All current output artifacts are uploaded to S3 artifact store async to the main workflow.

Also in accordance to work around the KFP caching logic, I had to add extra `.set_caching_options(False)` calls - steps now do not depend on input artifacts, therefore KFP presumes they don't change and caches their execution - which results in data not being populated on PVCs.

![image](https://github.com/user-attachments/assets/3847de9c-e16d-46a3-816d-41cab74c65f6)