### PR TITLE
WIP: Pass RHELAI_IMAGE to pytorchjobs via envvar

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -36,6 +36,7 @@ from utils import (
     pvc_to_model_op,
     pvc_to_mt_bench_op,
 )
+from utils.consts import RHELAI_IMAGE  # To pass to training PyTorchJobs
 
 TEACHER_CONFIG_MAP = "teacher-server"
 TEACHER_SECRET = "teacher-server"
@@ -281,6 +282,7 @@ def ilab_pipeline(
         seed=train_seed,
     )
     training_phase_1.after(data_processing_task, model_to_pvc_task)
+    training_phase_1.set_env_variable("TRAINING_PYTORCHJOB_BASE_IMAGE", RHELAI_IMAGE)
     training_phase_1.set_caching_options(False)
 
     #### Train 2
@@ -302,6 +304,7 @@ def ilab_pipeline(
     )
 
     training_phase_2.set_caching_options(False)
+    training_phase_2.set_env_variable("TRAINING_PYTORCHJOB_BASE_IMAGE", RHELAI_IMAGE)
     training_phase_2.after(training_phase_1)
 
     mount_pvc(

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -747,8 +747,8 @@ deploymentSpec:
           \       path_to_data = \"/input_data/knowledge/data.jsonl\"\n    elif phase_num\
           \ == 2:\n        path_to_model = list_phase1_final_model()\n        path_to_data\
           \ = \"/input_data/skills/data.jsonl\"\n    else:\n        raise RuntimeError(f\"\
-          Unsupported value of {phase_num=}\")\n\n    image = \"registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.3.1\"\
-          \n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
+          Unsupported value of {phase_num=}\")\n\n    image = os.getenv(\"TRAINING_PYTORCHJOB_BASE_IMAGE\"\
+          )\n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
           \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
           \   name: {name}\n        spec:\n          nprocPerNode: \\\"{nproc_per_node}\\\
           \"\n          pytorchReplicaSpecs:\n            Master:\n              replicas:\
@@ -914,6 +914,9 @@ deploymentSpec:
           \ as e:\n            print(f\"Connection broken reconnecting the watcher\
           \ {str(e)}\")\n            time.sleep(5)  # Backoff before retrying\n  \
           \      finally:\n            w.stop()\n\n"
+        env:
+        - name: TRAINING_PYTORCHJOB_BASE_IMAGE
+          value: registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.3.1
         image: quay.io/modh/odh-generic-data-science-notebook:v3-2024b-20241111
     exec-pytorchjob-manifest-op-2:
       container:
@@ -951,8 +954,8 @@ deploymentSpec:
           \       path_to_data = \"/input_data/knowledge/data.jsonl\"\n    elif phase_num\
           \ == 2:\n        path_to_model = list_phase1_final_model()\n        path_to_data\
           \ = \"/input_data/skills/data.jsonl\"\n    else:\n        raise RuntimeError(f\"\
-          Unsupported value of {phase_num=}\")\n\n    image = \"registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.3.1\"\
-          \n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
+          Unsupported value of {phase_num=}\")\n\n    image = os.getenv(\"TRAINING_PYTORCHJOB_BASE_IMAGE\"\
+          )\n\n    manifest = inspect.cleandoc(\n        f\"\"\"\n        apiVersion:\
           \ kubeflow.org/v1\n        kind: PyTorchJob\n        metadata:\n       \
           \   name: {name}\n        spec:\n          nprocPerNode: \\\"{nproc_per_node}\\\
           \"\n          pytorchReplicaSpecs:\n            Master:\n              replicas:\
@@ -1118,6 +1121,9 @@ deploymentSpec:
           \ as e:\n            print(f\"Connection broken reconnecting the watcher\
           \ {str(e)}\")\n            time.sleep(5)  # Backoff before retrying\n  \
           \      finally:\n            w.stop()\n\n"
+        env:
+        - name: TRAINING_PYTORCHJOB_BASE_IMAGE
+          value: registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.3.1
         image: quay.io/modh/odh-generic-data-science-notebook:v3-2024b-20241111
     exec-run-final-eval-op:
       container:

--- a/training/components.py
+++ b/training/components.py
@@ -167,7 +167,7 @@ def pytorchjob_manifest_op(
     else:
         raise RuntimeError(f"Unsupported value of {phase_num=}")
 
-    image = "registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.3.1"
+    image = os.getenv("TRAINING_PYTORCHJOB_BASE_IMAGE")
 
     manifest = inspect.cleandoc(
         f"""


### PR DESCRIPTION
Pass the pytorchjob base image reference via environment variable

## Description
Get around hardcoded RHELAI Image used for Training PyTorchJobs by passing the const (which is already defined in `util/consts.py`) to the manifest op via an env var.  This will mean that *all* image references are now centralized in `util/consts.py`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
